### PR TITLE
Mark unused and unhooked code across codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ test_*.c
 
 # Internal planning docs (not for public repo)
 ROADMAP.md
+BUGS.md

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,3 +1,17 @@
+/*
+ * DEAD CODE — entire file is unused.
+ *
+ * Replaced by: libevent's evbuffer (v6 rewrite). connection.c notes:
+ *   "v6: No more request_buffer allocation - we use evbuffer directly."
+ *   "v6: No more request_buffer to free."
+ *
+ * The only caller was reader.c's read_request_line(), which is also dead code.
+ * No production or test code calls any function in this file.
+ * Still compiled via Makefile but nothing links to it.
+ *
+ * Safe to remove this file and include/buffer.h.
+ */
+
 #include "buffer.h"
 #include <stdlib.h>
 #include <string.h>

--- a/src/http2.c
+++ b/src/http2.c
@@ -644,7 +644,9 @@ int h2_send_response(Connection *conn, int32_t stream_id,
 }
 
 /*
- * Send error response (RST_STREAM).
+ * UNHOOKED: Not called from production or test code.
+ * The one place that sends RST_STREAM (h2_on_header_callback, line ~387)
+ * calls nghttp2_submit_rst_stream() directly instead of using this wrapper.
  */
 int h2_send_error(Connection *conn, int32_t stream_id, uint32_t error_code)
 {

--- a/src/network.c
+++ b/src/network.c
@@ -71,12 +71,19 @@ const char *network_chain_to_string(BitcoinChain chain)
     }
 }
 
+/* UNHOOKED: Not currently called from production code.
+ * Intended for X-Bitcoin-Network HTTP response header (see test_integration.sh SKIP note). */
 const char *network_get_header_value(BitcoinChain chain)
 {
     /* Same as chain_to_string for now, but separate function
      * in case we want different formatting later */
     return network_chain_to_string(chain);
 }
+
+/* UNHOOKED: detect_address_network() and the functions that call it
+ * (network_check_address, network_get_address_warning, network_detect_chain_from_address,
+ * network_detect_chain_from_address_with_hint) are Phase 13 mixed-mode address routing
+ * infrastructure. Backend logic is complete but no request handler calls into it yet. */
 
 /*
  * Detect which network an address belongs to based on prefix.
@@ -127,6 +134,7 @@ static int detect_address_network(const char *address)
     return -1;
 }
 
+/* UNHOOKED: Not called from production code. Part of mixed-mode address routing. */
 AddressCheckResult network_check_address(BitcoinChain expected,
                                          const char *address,
                                          BitcoinChain *detected_network)
@@ -171,6 +179,7 @@ AddressCheckResult network_check_address(BitcoinChain expected,
     return ADDR_WRONG_NETWORK;
 }
 
+/* UNHOOKED: Not called from production code. Part of mixed-mode address routing. */
 const char *network_get_address_warning(BitcoinChain server_chain,
                                         BitcoinChain address_chain)
 {
@@ -219,6 +228,7 @@ int network_is_test_network(BitcoinChain chain)
     return chain != CHAIN_MAINNET && chain != CHAIN_MIXED;
 }
 
+/* UNHOOKED: Not called from production code. Intended for HTML test-network banners. */
 const char *network_get_banner_text(BitcoinChain chain)
 {
     switch (chain) {
@@ -236,6 +246,7 @@ const char *network_get_banner_text(BitcoinChain chain)
     }
 }
 
+/* UNHOOKED: Not called from production code. Intended for HTML test-network banner CSS. */
 const char *network_get_banner_class(BitcoinChain chain)
 {
     switch (chain) {
@@ -253,11 +264,13 @@ const char *network_get_banner_class(BitcoinChain chain)
     }
 }
 
+/* UNHOOKED: Called from test_network.c only. Not called from production code. */
 int network_detect_chain_from_address(const char *address)
 {
     return detect_address_network(address);
 }
 
+/* UNHOOKED: Not called from production or test code. */
 int network_detect_chain_from_address_with_hint(const char *address, BitcoinChain hint)
 {
     int detected = detect_address_network(address);

--- a/src/reader.c
+++ b/src/reader.c
@@ -1,3 +1,16 @@
+/*
+ * MOSTLY DEAD CODE — only tier_name() and size_to_tier() are still used.
+ *
+ * read_request_line() and its helpers (approaching_threshold, calculate_read_size,
+ * wait_for_read, find_newline) were the synchronous select()+read() reader,
+ * replaced by libevent bufferevent async I/O in connection.c (v6 rewrite).
+ *
+ * LIVE functions (called from connection.c and http2.c):
+ *   - tier_name()     — returns human-readable tier name
+ *   - size_to_tier()  — maps request size to tier enum
+ * These two should be factored into their own file if reader.c is removed.
+ */
+
 #include "reader.h"
 #include <unistd.h>
 #include <errno.h>
@@ -26,6 +39,10 @@ RequestTier size_to_tier(size_t size, Config *cfg)
     }
     return TIER_NORMAL;
 }
+
+/* DEAD CODE below: approaching_threshold, calculate_read_size, wait_for_read,
+ * find_newline, and read_request_line are all unused since the v6 rewrite.
+ * Only called internally by read_request_line(), which has no callers. */
 
 /*
  * Check if we're approaching a threshold.

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -169,6 +169,8 @@ int rpc_init(RPCClient *client, const RPCConfig *config, BitcoinChain chain)
     return RPC_OK;
 }
 
+/* UNHOOKED: Convenience wrapper used in tests (test_rpc.c, test_async_rpc.c) only.
+ * Production uses rpc_init() via rpc_manager_init(). */
 int rpc_init_simple(RPCClient *client, const char *host, int port,
                     const char *user, const char *password, BitcoinChain chain)
 {
@@ -183,6 +185,8 @@ int rpc_init_simple(RPCClient *client, const char *host, int port,
     return rpc_init(client, &config, chain);
 }
 
+/* UNHOOKED: Convenience wrapper used in tests (test_rpc.c) only.
+ * Production uses rpc_init() via rpc_manager_init(). */
 int rpc_init_cookie(RPCClient *client, const char *host, int port,
                     const char *cookie_path, BitcoinChain chain)
 {
@@ -569,6 +573,7 @@ static int rpc_call(RPCClient *client, const char *method, const char *params,
     return ret;
 }
 
+/* UNHOOKED: Used in tests (test_rpc.c) only. Not called from production code. */
 int rpc_test_connection(RPCClient *client)
 {
     char result[256];
@@ -609,11 +614,15 @@ int rpc_sendrawtransaction(RPCClient *client, const char *hex_tx,
     return ret;
 }
 
+/* UNHOOKED: Used in tests (test_rpc.c, test_async_rpc.c) only.
+ * Not called from production code. Planned for future node status features. */
 int rpc_getblockchaininfo(RPCClient *client, char *result, size_t result_sz)
 {
     return rpc_call(client, "getblockchaininfo", "[]", result, result_sz);
 }
 
+/* UNHOOKED: Not called from production or test code.
+ * Planned for future transaction lookup features. */
 int rpc_getrawtransaction(RPCClient *client, const char *txid,
                           char *result, size_t result_sz)
 {
@@ -622,6 +631,8 @@ int rpc_getrawtransaction(RPCClient *client, const char *txid,
     return rpc_call(client, "getrawtransaction", params, result, result_sz);
 }
 
+/* UNHOOKED: Not called from production or test code.
+ * Planned for future mempool inspection features. */
 int rpc_getmempoolentry(RPCClient *client, const char *txid,
                         char *result, size_t result_sz)
 {
@@ -630,6 +641,8 @@ int rpc_getmempoolentry(RPCClient *client, const char *txid,
     return rpc_call(client, "getmempoolentry", params, result, result_sz);
 }
 
+/* UNHOOKED: Used in tests (test_rpc.c) only. Not called from production code.
+ * Planned for future transaction decode/display features. */
 int rpc_decoderawtransaction(RPCClient *client, const char *hex_tx,
                              char *result, size_t result_sz)
 {
@@ -643,6 +656,8 @@ int rpc_decoderawtransaction(RPCClient *client, const char *hex_tx,
     return ret;
 }
 
+/* UNHOOKED: Not called from production or test code.
+ * Planned for future pre-broadcast validation features. */
 int rpc_testmempoolaccept(RPCClient *client, const char *hex_tx,
                           char *result, size_t result_sz)
 {
@@ -704,6 +719,8 @@ RPCClient *rpc_manager_get_client(RPCManager *mgr, BitcoinChain chain)
     }
 }
 
+/* UNHOOKED: Sync broadcast — used in tests (test_async_rpc.c) only.
+ * Production uses rpc_manager_broadcast_async() instead. */
 int rpc_manager_broadcast(RPCManager *mgr, BitcoinChain chain,
                           const char *hex_tx, char *txid, size_t txid_sz)
 {

--- a/src/slot_manager.c
+++ b/src/slot_manager.c
@@ -108,26 +108,24 @@ int slot_manager_max(SlotManager *sm, RequestTier tier)
     }
 }
 
+/* UNHOOKED: Not called from production or test code. */
 int slot_manager_total_connections(SlotManager *sm)
 {
     return sm->normal_current + sm->large_current + sm->huge_current;
 }
 
 /*
- * Acquire a slot for a new request (keep-alive).
- * Same as slot_manager_acquire but semantically different:
- * used for request-level (not connection-level) slot tracking.
+ * UNHOOKED: Not called from production or test code.
+ * Written for a planned per-request (vs per-connection) slot tracking model
+ * that was never adopted. Keep-alive code in connection.c uses
+ * slot_manager_acquire()/slot_manager_release() directly instead.
  */
 int slot_manager_acquire_request(SlotManager *sm, RequestTier tier)
 {
     return slot_manager_acquire(sm, tier);
 }
 
-/*
- * Release a slot after completing a request (keep-alive).
- * Same as slot_manager_release but semantically different:
- * used for request-level slot tracking.
- */
+/* UNHOOKED: See slot_manager_acquire_request() note above. */
 void slot_manager_release_request(SlotManager *sm, RequestTier tier)
 {
     slot_manager_release(sm, tier);


### PR DESCRIPTION
## Summary
- Tag dead code (buffer.c, reader.c) with DEAD CODE markers explaining what replaced each file
- Tag unhooked functions in network.c, rpc.c, slot_manager.c, http2.c with UNHOOKED markers
- Add BUGS.md to gitignore

Comment-only changes, zero functional code modified.