### PR TITLE
Fix TLS slot leak, HTTP/2 safety bugs, and add TLS tests

### DIFF
--- a/include/connection.h
+++ b/include/connection.h
@@ -114,6 +114,16 @@ Connection *connection_new(struct WorkerProcess *worker, evutil_socket_t fd,
                            struct sockaddr *addr, int addrlen);
 
 /*
+ * Create a new connection from a pre-created bufferevent.
+ * Used by TLS accept path where bufferevent_openssl_socket_new()
+ * has already created the bufferevent.
+ * Does NOT take ownership of bev on failure (caller must free).
+ */
+Connection *connection_new_with_bev(struct WorkerProcess *worker,
+                                     struct bufferevent *bev,
+                                     struct sockaddr *addr, int addrlen);
+
+/*
  * Close and free a connection.
  */
 void connection_free(Connection *conn);

--- a/include/worker.h
+++ b/include/worker.h
@@ -60,6 +60,7 @@ typedef struct WorkerProcess {
     /* State flags */
     volatile bool draining;
     bool listener_disabled;
+    bool tls_listener_disabled;
 
     /* Statistics */
     uint64_t connections_accepted;


### PR DESCRIPTION
## Summary

- **TLS slot leak (critical)**: `tls_accept_cb()` used `calloc()` instead of `connection_new()`, so `slot_held` was never set to `true`. Every TLS connection permanently leaked one slot. Fixed by extracting `connection_init_common()` and adding `connection_new_with_bev()` for TLS connections.
- **HTTP/2 session kill on slot exhaustion**: `begin_headers` returned `NGHTTP2_ERR_CALLBACK_FAILURE` which kills the entire HTTP/2 session. Changed to `NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE` to reject only the individual stream (RST_STREAM).
- **HTTP/2 body use-after-free**: `h2_send_response()` stored a pointer to caller's stack buffer (`char body[8192]`). The buffer goes out of scope before nghttp2 reads it asynchronously. Fixed by copying body data into owned allocation.
- **Drain misses TLS listener**: `worker_check_drain()` only disabled the HTTP listener. TLS listener kept accepting during graceful drain.

## Files changed

| File | What |
|------|------|
| `src/connection.c` | Extract `connection_init_common()`, add `connection_new_with_bev()` |
| `include/connection.h` | Declare `connection_new_with_bev()` |
| `src/worker.c` | Simplify `tls_accept_cb()`, fix `worker_check_drain()` for TLS |
| `include/worker.h` | Add `tls_listener_disabled` field |
| `src/http2.c` | Fix begin_headers error code, copy body in `h2_send_response()` |
| `tests/gen_test_certs.sh` | Self-signed EC P-256 cert generator |
| `tests/config.tls.ini` | TLS test configuration |
| `tests/test_tls.sh` | TLS integration tests (connectivity, slot accounting, drain) |
| `tests/test_tls_stress.sh` | TLS stress tests (100 sequential, 50 concurrent, soak, leak detection) |
| `.github/workflows/ci.yml` | Add TLS test and stress test CI jobs |

## Test plan

- [ ] `make` compiles cleanly
- [ ] `make test` (existing unit tests) still pass
- [ ] `bash tests/test_tls.sh` — TLS integration: connectivity, slot accounting after close shows 0, keep-alive, cert reload, drain stops both listeners
- [ ] `bash tests/test_tls_stress.sh` — 100 sequential + 50 concurrent + 200 rapid + 30s soak all show `slots_used == 0` after
- [ ] Existing `tests/test_integration.sh` still passes (plain HTTP unchanged)