### PR TITLE
Add a /version route to return current server version

### DIFF
--- a/include/router.h
+++ b/include/router.h
@@ -20,6 +20,7 @@ typedef enum {
     ROUTE_READY,           /* /ready → readiness probe */
     ROUTE_ALIVE,           /* /alive → liveness probe */
     ROUTE_METRICS,         /* /metrics → Prometheus metrics */
+    ROUTE_VERSION,         /* /version → version info */
     ROUTE_ACME_CHALLENGE   /* /.well-known/acme-challenge/{token} */
 } RouteType;
 
@@ -27,6 +28,7 @@ typedef enum {
  * Determine route for a request path.
  *
  * Routing logic:
+ * - / → ROUTE_HOME
  * - /tx/{64-hex-chars} → ROUTE_RESULT
  * - /{64-hex-chars} → ROUTE_RESULT (bare txid)
  * - /{>64-hex-chars} → ROUTE_BROADCAST (raw tx)

--- a/src/connection.c
+++ b/src/connection.c
@@ -641,6 +641,36 @@ static void serve_ready(Connection *conn)
     bufferevent_enable(conn->bev, EV_WRITE);
 }
 
+
+/*
+* Serve /version endpoint - returns version info in JSON.
+* Returns 200 if healthy.
+*/
+static void serve_version(Connection *conn)
+{
+    struct evbuffer *output = bufferevent_get_output(conn->bev);
+    char body[256];
+    int body_len = snprintf(body, sizeof(body), "{\"version\":\"0.1.0\"}");
+
+    conn->state = CONN_STATE_WRITING_RESPONSE;
+
+    evbuffer_add_printf(output,
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: %d\r\n"
+        "Cache-Control: no-store\r\n"
+        "X-Request-ID: %s\r\n"
+        "Connection: %s\r\n"
+        "\r\n%s",
+        body_len, conn->request_id,
+        conn->keep_alive ? "keep-alive" : "close", body);
+
+    conn->response_status = 200;
+    conn->response_bytes = body_len;
+    conn->state = conn->keep_alive ? CONN_STATE_WRITING_RESPONSE : CONN_STATE_CLOSING;
+    bufferevent_enable(conn->bev, EV_WRITE);
+}
+
 /*
  * Serve /alive endpoint - liveness probe.
  * Always returns 200 if the process is running.
@@ -1131,6 +1161,9 @@ static void process_request(Connection *conn)
             return;
         case ROUTE_READY:
             serve_ready(conn);
+            return;
+        case ROUTE_VERSION:
+            serve_version(conn);
             return;
         case ROUTE_ALIVE:
             serve_alive(conn);

--- a/src/router.c
+++ b/src/router.c
@@ -30,6 +30,9 @@ RouteType route_request(const char *path, size_t path_len)
     if (content_len == 5 && strncmp(content, "ready", 5) == 0) {
         return ROUTE_READY;
     }
+    if (content_len == 7 && strncmp(content, "version", 7) == 0) {
+        return ROUTE_VERSION;
+    }
     if (content_len == 5 && strncmp(content, "alive", 5) == 0) {
         return ROUTE_ALIVE;
     }

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -81,6 +81,16 @@ else
     fail "/ready (got $CODE)"
 fi
 
+# Test /version
+RESP=$(curl -s -w "\n%{http_code}" "${BASE_URL}/version")
+CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$CODE" = "200" ] && echo "$BODY" | grep -q '"version"\s*:\s*"0.1.0"'; then
+    pass "/version returns 200 with version 0.1.0"
+else
+    fail "/version (got $CODE)"
+fi
+
 # Test /alive
 RESP=$(curl -s -w "\n%{http_code}" "${BASE_URL}/alive")
 CODE=$(echo "$RESP" | tail -1)


### PR DESCRIPTION
## What does this PR do?
Fixes #6 

Brief description of the change.

Describes and implement an API route that returns the current version of the server.

## Checklist

- [x] Builds with `make` (no warnings with `-Wall -Wextra -Werror`)
- [x] Tests pass (`make test`)
- [x] Integration tests pass (`./tests/test_integration.sh`)
- [x] New tests added for new functionality
- [ ] Valgrind clean (no leaks, no errors)
- [x] Code follows project style (4-space indent, `snake_case`)
- [ ] Documentation updated if needed

## Testing done

Describe what you tested and how. Include commands you ran.
Tests ensure that the /version route is available and that the JSON response contains a "version" key with a "string" response = "0.1.0"
