### PR TITLE
HTTP/2 feature parity, TLS hardening, endpoint extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SRCS = $(SRC_DIR)/main.c \
        $(SRC_DIR)/rate_limiter.c \
        $(SRC_DIR)/ip_acl.c \
        $(SRC_DIR)/tls.c \
+       $(SRC_DIR)/endpoints.c \
        $(SRC_DIR)/http2.c \
        $(SRC_DIR)/security.c \
        $(SRC_DIR)/network.c \

--- a/include/connection.h
+++ b/include/connection.h
@@ -140,10 +140,4 @@ void connection_send_response(Connection *conn, int status_code,
 void connection_send_error(Connection *conn, int status_code,
                            const char *status_text);
 
-/*
- * Set up callbacks for a connection.
- * Used by TLS accept to configure bufferevent callbacks.
- */
-void connection_set_callbacks(Connection *conn);
-
 #endif /* CONNECTION_H */

--- a/include/endpoints.h
+++ b/include/endpoints.h
@@ -1,0 +1,74 @@
+#ifndef ENDPOINTS_H
+#define ENDPOINTS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Forward declarations */
+struct WorkerProcess;
+struct Connection;
+
+/*
+ * Generate /health JSON response body.
+ * Writes into caller-provided buffer.
+ * Returns number of bytes written (excluding NUL), or -1 on error.
+ */
+int generate_health_body(struct WorkerProcess *worker, char *buf, size_t bufsize);
+
+/*
+ * Generate /metrics Prometheus response body.
+ * Writes into caller-provided buffer.
+ * Returns number of bytes written (excluding NUL), or -1 on error.
+ */
+int generate_metrics_body(struct WorkerProcess *worker, char *buf, size_t bufsize);
+
+/*
+ * Serve ACME HTTP-01 challenge for HTTP/2.
+ * Reads the challenge file and sends the response via h2_send_response().
+ * The path must start with "/.well-known/acme-challenge/".
+ *
+ * @param conn       Connection (for h2_send_response and client_ip logging)
+ * @param stream_id  HTTP/2 stream ID
+ * @param path       Full request path (e.g., "/.well-known/acme-challenge/token")
+ * @param path_len   Length of path
+ * @param request_id Request ID for X-Request-ID header
+ * @return body length on success (>0), -1 on error (404 sent)
+ */
+int serve_acme_challenge_h2(struct Connection *conn, int32_t stream_id,
+                            const char *path, size_t path_len,
+                            const char *request_id);
+
+/*
+ * Validate hex characters in a path buffer.
+ * For paths > 64 chars that look like transaction hex, validates each character.
+ * Allows "tx/" prefix.
+ *
+ * @param path     Path content after leading slash (e.g., "abcdef..." or "tx/abcdef...")
+ * @param path_len Length of path content
+ * @return 0 if valid (or too short to validate), -1 if invalid hex found
+ */
+int validate_hex_path(const char *path, size_t path_len);
+
+/*
+ * Update latency histogram bucket based on duration in seconds.
+ */
+void update_latency_histogram(struct WorkerProcess *worker, double duration_sec);
+
+/*
+ * Update HTTP status code counters.
+ */
+void update_status_counters(struct WorkerProcess *worker, int status);
+
+/*
+ * Update HTTP method counters.
+ */
+void update_method_counters(struct WorkerProcess *worker, const char *method);
+
+/*
+ * Log access entry for a completed request.
+ */
+void log_request_access(const char *client_ip, const char *method,
+                        const char *path, int status, size_t bytes_sent,
+                        double duration_ms, const char *request_id);
+
+#endif /* ENDPOINTS_H */

--- a/include/http2.h
+++ b/include/http2.h
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/time.h>
 #include <event2/bufferevent.h>
 
 /* Forward declarations */
@@ -47,6 +48,12 @@ typedef struct H2Stream {
     /* Request body */
     size_t content_length;
     size_t body_received;
+
+    /* Per-stream request tracking */
+    char request_id[32];           /* Per-stream request ID */
+    struct timeval start_time;     /* Stream start time for latency */
+    int response_status;           /* HTTP status code sent */
+    size_t response_bytes;         /* Response body size */
 
     /* Response body source (for cleanup) */
     void *body_source;
@@ -121,10 +128,5 @@ void h2_stream_free(H2Connection *h2, H2Stream *stream);
 int h2_send_response(struct Connection *conn, int32_t stream_id,
                      int status_code, const char *content_type,
                      const unsigned char *body, size_t body_len);
-
-/*
- * Send HTTP/2 error response (RST_STREAM with error code).
- */
-int h2_send_error(struct Connection *conn, int32_t stream_id, uint32_t error_code);
 
 #endif /* HTTP2_H */

--- a/src/connection.c
+++ b/src/connection.c
@@ -7,6 +7,7 @@
 #include "http2.h"
 #include "tls.h"
 #include "hex.h"
+#include "endpoints.h"
 #include "log.h"
 
 #include <stdlib.h>
@@ -14,9 +15,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <sys/time.h>
-#include <sys/resource.h>
 #include <sys/stat.h>
-#include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <arpa/inet.h>
@@ -39,8 +38,6 @@ static void conn_event_cb(struct bufferevent *bev, short events, void *ctx);
 static int parse_request_headers(Connection *conn, const unsigned char *headers, size_t len);
 static int try_promote_tier(Connection *conn, size_t new_size);
 static int validate_path_early(Connection *conn, const unsigned char *data, size_t len);
-static int get_open_fds(void);
-static int get_max_fds(void);
 
 /*
  * Early validation of path data as it arrives.
@@ -584,65 +581,10 @@ static void serve_health(Connection *conn)
     WorkerProcess *worker = conn->worker;
     struct evbuffer *output = bufferevent_get_output(conn->bev);
     char body[1024];
-    int body_len;
 
     conn->state = CONN_STATE_WRITING_RESPONSE;
 
-    /* Calculate uptime */
-    struct timeval now;
-    gettimeofday(&now, NULL);
-    long uptime_sec = now.tv_sec - worker->start_time.tv_sec;
-
-    /* Get FD counts */
-    int open_fds = get_open_fds();
-    int max_fds = get_max_fds();
-    double fd_usage_pct = (max_fds > 0) ? (100.0 * open_fds / max_fds) : 0.0;
-
-    /* Check if TLS is enabled and get cert expiry */
-    int tls_enabled = (worker->tls.ctx != NULL) ? 1 : 0;
-    time_t cert_expiry = tls_get_cert_expiry(&worker->tls);
-    int cert_days_remaining = 0;
-    int cert_warning = 0;
-    if (cert_expiry > 0) {
-        cert_days_remaining = (int)((cert_expiry - now.tv_sec) / 86400);
-        cert_warning = (cert_days_remaining < 30) ? 1 : 0;
-    }
-
-    body_len = snprintf(body, sizeof(body),
-        "{\"status\":\"healthy\","
-        "\"worker_id\":%d,"
-        "\"uptime_seconds\":%ld,"
-        "\"active_connections\":%d,"
-        "\"requests_processed\":%lu,"
-        "\"slots\":{"
-            "\"normal\":{\"used\":%d,\"max\":%d},"
-            "\"large\":{\"used\":%d,\"max\":%d},"
-            "\"huge\":{\"used\":%d,\"max\":%d}"
-        "},"
-        "\"rate_limiter_entries\":%d,"
-        "\"tls\":{\"enabled\":%s,\"cert_expires_in_days\":%d,\"cert_expiry_warning\":%s},"
-        "\"resources\":{"
-            "\"open_fds\":%d,"
-            "\"max_fds\":%d,"
-            "\"fd_usage_percent\":%.1f"
-        "}}",
-        worker->worker_id,
-        uptime_sec,
-        worker->active_connections,
-        (unsigned long)worker->requests_processed,
-        slot_manager_current(&worker->slots, TIER_NORMAL),
-        slot_manager_max(&worker->slots, TIER_NORMAL),
-        slot_manager_current(&worker->slots, TIER_LARGE),
-        slot_manager_max(&worker->slots, TIER_LARGE),
-        slot_manager_current(&worker->slots, TIER_HUGE),
-        slot_manager_max(&worker->slots, TIER_HUGE),
-        rate_limiter_get_entry_count(&worker->rate_limiter),
-        tls_enabled ? "true" : "false",
-        cert_days_remaining,
-        cert_warning ? "true" : "false",
-        open_fds,
-        max_fds,
-        fd_usage_pct);
+    int body_len = generate_health_body(worker, body, sizeof(body));
 
     evbuffer_add_printf(output,
         "HTTP/1.1 200 OK\r\n"
@@ -846,317 +788,32 @@ not_found:
 }
 
 /*
- * Get number of open file descriptors for this process.
- */
-static int get_open_fds(void)
-{
-#ifdef __linux__
-    int count = 0;
-    DIR *dir = opendir("/proc/self/fd");
-    if (dir) {
-        struct dirent *entry;
-        while ((entry = readdir(dir)) != NULL) {
-            if (entry->d_name[0] != '.') {
-                count++;
-            }
-        }
-        closedir(dir);
-    }
-    return count;
-#else
-    return -1;  /* Not available on this platform */
-#endif
-}
-
-/*
- * Get maximum file descriptors for this process.
- */
-static int get_max_fds(void)
-{
-    struct rlimit rl;
-    if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
-        return (int)rl.rlim_cur;
-    }
-    return -1;
-}
-
-/*
  * Serve /metrics endpoint - Prometheus text exposition format.
  */
 static void serve_metrics(Connection *conn)
 {
     WorkerProcess *worker = conn->worker;
     struct evbuffer *output = bufferevent_get_output(conn->bev);
-    char body[8192];  /* Larger buffer for all metrics */
-    size_t offset = 0;
-    size_t remaining = sizeof(body) - 1;  /* Reserve space for null terminator */
-    int n;
-
-    /* Helper macro to safely advance buffer position */
-    #define METRICS_ADVANCE() do { \
-        if (n > 0 && (size_t)n < remaining) { \
-            offset += (size_t)n; \
-            remaining -= (size_t)n; \
-        } else { \
-            remaining = 0; \
-        } \
-    } while(0)
+    char body[8192];
 
     conn->state = CONN_STATE_WRITING_RESPONSE;
 
-    /* Calculate uptime */
-    struct timeval now;
-    gettimeofday(&now, NULL);
-    double uptime_sec = (now.tv_sec - worker->start_time.tv_sec) +
-                        (now.tv_usec - worker->start_time.tv_usec) / 1000000.0;
-
-    /* Get FD counts */
-    int open_fds = get_open_fds();
-    int max_fds = get_max_fds();
-
-    /* === Basic Counters === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_requests_total Total requests processed\n"
-        "# TYPE rawrelay_requests_total counter\n"
-        "rawrelay_requests_total{worker=\"%d\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_connections_accepted_total Total connections accepted\n"
-        "# TYPE rawrelay_connections_accepted_total counter\n"
-        "rawrelay_connections_accepted_total{worker=\"%d\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_connections_rejected_total Rejected connections by reason\n"
-        "# TYPE rawrelay_connections_rejected_total counter\n"
-        "rawrelay_connections_rejected_total{worker=\"%d\",reason=\"rate_limit\"} %lu\n"
-        "rawrelay_connections_rejected_total{worker=\"%d\",reason=\"slot_limit\"} %lu\n"
-        "rawrelay_connections_rejected_total{worker=\"%d\",reason=\"blocked\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_connections_allowlisted_total Connections that bypassed rate limiting\n"
-        "# TYPE rawrelay_connections_allowlisted_total counter\n"
-        "rawrelay_connections_allowlisted_total{worker=\"%d\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_active_connections Current active connections\n"
-        "# TYPE rawrelay_active_connections gauge\n"
-        "rawrelay_active_connections{worker=\"%d\"} %d\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->requests_processed,
-        worker->worker_id, (unsigned long)worker->connections_accepted,
-        worker->worker_id, (unsigned long)worker->connections_rejected_rate,
-        worker->worker_id, (unsigned long)worker->connections_rejected_slot,
-        worker->worker_id, (unsigned long)worker->connections_rejected_blocked,
-        worker->worker_id, (unsigned long)worker->connections_allowlisted,
-        worker->worker_id, worker->active_connections);
-    METRICS_ADVANCE();
-
-    /* === Request Latency Histogram === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_request_duration_seconds Request latency histogram\n"
-        "# TYPE rawrelay_request_duration_seconds histogram\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.001\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.005\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.01\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.05\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.1\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.5\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"1\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"5\"} %lu\n"
-        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"+Inf\"} %lu\n"
-        "rawrelay_request_duration_seconds_sum{worker=\"%d\"} %.6f\n"
-        "rawrelay_request_duration_seconds_count{worker=\"%d\"} %lu\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->latency_bucket_1ms,
-        worker->worker_id, (unsigned long)worker->latency_bucket_5ms,
-        worker->worker_id, (unsigned long)worker->latency_bucket_10ms,
-        worker->worker_id, (unsigned long)worker->latency_bucket_50ms,
-        worker->worker_id, (unsigned long)worker->latency_bucket_100ms,
-        worker->worker_id, (unsigned long)worker->latency_bucket_500ms,
-        worker->worker_id, (unsigned long)worker->latency_bucket_1s,
-        worker->worker_id, (unsigned long)worker->latency_bucket_5s,
-        worker->worker_id, (unsigned long)worker->latency_bucket_inf,
-        worker->worker_id, worker->latency_sum_seconds,
-        worker->worker_id, (unsigned long)worker->latency_bucket_inf);
-    METRICS_ADVANCE();
-
-    /* === HTTP Status Code Counters === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_http_requests_total HTTP requests by status code\n"
-        "# TYPE rawrelay_http_requests_total counter\n"
-        "rawrelay_http_requests_total{worker=\"%d\",status=\"200\"} %lu\n"
-        "rawrelay_http_requests_total{worker=\"%d\",status=\"400\"} %lu\n"
-        "rawrelay_http_requests_total{worker=\"%d\",status=\"404\"} %lu\n"
-        "rawrelay_http_requests_total{worker=\"%d\",status=\"408\"} %lu\n"
-        "rawrelay_http_requests_total{worker=\"%d\",status=\"429\"} %lu\n"
-        "rawrelay_http_requests_total{worker=\"%d\",status=\"503\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_http_requests_by_class_total HTTP requests by status class\n"
-        "# TYPE rawrelay_http_requests_by_class_total counter\n"
-        "rawrelay_http_requests_by_class_total{worker=\"%d\",class=\"2xx\"} %lu\n"
-        "rawrelay_http_requests_by_class_total{worker=\"%d\",class=\"4xx\"} %lu\n"
-        "rawrelay_http_requests_by_class_total{worker=\"%d\",class=\"5xx\"} %lu\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->status_200,
-        worker->worker_id, (unsigned long)worker->status_400,
-        worker->worker_id, (unsigned long)worker->status_404,
-        worker->worker_id, (unsigned long)worker->status_408,
-        worker->worker_id, (unsigned long)worker->status_429,
-        worker->worker_id, (unsigned long)worker->status_503,
-        worker->worker_id, (unsigned long)worker->status_2xx,
-        worker->worker_id, (unsigned long)worker->status_4xx,
-        worker->worker_id, (unsigned long)worker->status_5xx);
-    METRICS_ADVANCE();
-
-    /* === Request Method Counters === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_requests_by_method_total HTTP requests by method\n"
-        "# TYPE rawrelay_requests_by_method_total counter\n"
-        "rawrelay_requests_by_method_total{worker=\"%d\",method=\"GET\"} %lu\n"
-        "rawrelay_requests_by_method_total{worker=\"%d\",method=\"POST\"} %lu\n"
-        "rawrelay_requests_by_method_total{worker=\"%d\",method=\"OTHER\"} %lu\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->method_get,
-        worker->worker_id, (unsigned long)worker->method_post,
-        worker->worker_id, (unsigned long)worker->method_other);
-    METRICS_ADVANCE();
-
-    /* === Process Info === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_process_start_time_seconds Unix timestamp of process start\n"
-        "# TYPE rawrelay_process_start_time_seconds gauge\n"
-        "rawrelay_process_start_time_seconds{worker=\"%d\"} %ld\n"
-        "\n"
-        "# HELP rawrelay_process_uptime_seconds Process uptime in seconds\n"
-        "# TYPE rawrelay_process_uptime_seconds gauge\n"
-        "rawrelay_process_uptime_seconds{worker=\"%d\"} %.3f\n"
-        "\n",
-        worker->worker_id, (long)worker->start_time.tv_sec,
-        worker->worker_id, uptime_sec);
-    METRICS_ADVANCE();
-
-    /* === File Descriptor Metrics === */
-    if (open_fds >= 0 && max_fds >= 0) {
-        n = snprintf(body + offset, remaining,
-            "# HELP rawrelay_open_fds Current number of open file descriptors\n"
-            "# TYPE rawrelay_open_fds gauge\n"
-            "rawrelay_open_fds{worker=\"%d\"} %d\n"
-            "\n"
-            "# HELP rawrelay_max_fds Maximum file descriptors allowed\n"
-            "# TYPE rawrelay_max_fds gauge\n"
-            "rawrelay_max_fds{worker=\"%d\"} %d\n"
-            "\n",
-            worker->worker_id, open_fds,
-            worker->worker_id, max_fds);
-        METRICS_ADVANCE();
-    }
-
-    /* === TLS Metrics === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_tls_handshakes_total TLS handshakes by protocol version\n"
-        "# TYPE rawrelay_tls_handshakes_total counter\n"
-        "rawrelay_tls_handshakes_total{worker=\"%d\",protocol=\"TLSv1.2\"} %lu\n"
-        "rawrelay_tls_handshakes_total{worker=\"%d\",protocol=\"TLSv1.3\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_tls_handshake_errors_total TLS handshake errors\n"
-        "# TYPE rawrelay_tls_handshake_errors_total counter\n"
-        "rawrelay_tls_handshake_errors_total{worker=\"%d\"} %lu\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->tls_protocol_tls12,
-        worker->worker_id, (unsigned long)worker->tls_protocol_tls13,
-        worker->worker_id, (unsigned long)worker->tls_handshake_errors);
-    METRICS_ADVANCE();
-
-    /* === TLS Certificate Expiry === */
-    time_t cert_expiry = tls_get_cert_expiry(&worker->tls);
-    if (cert_expiry > 0) {
-        n = snprintf(body + offset, remaining,
-            "# HELP rawrelay_tls_cert_expiry_timestamp_seconds Unix timestamp when certificate expires\n"
-            "# TYPE rawrelay_tls_cert_expiry_timestamp_seconds gauge\n"
-            "rawrelay_tls_cert_expiry_timestamp_seconds{worker=\"%d\"} %ld\n"
-            "\n",
-            worker->worker_id, (long)cert_expiry);
-        METRICS_ADVANCE();
-    }
-
-    /* === HTTP/2 Metrics === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_http2_streams_total Total HTTP/2 streams opened\n"
-        "# TYPE rawrelay_http2_streams_total counter\n"
-        "rawrelay_http2_streams_total{worker=\"%d\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_http2_streams_active Current active HTTP/2 streams\n"
-        "# TYPE rawrelay_http2_streams_active gauge\n"
-        "rawrelay_http2_streams_active{worker=\"%d\"} %d\n"
-        "\n"
-        "# HELP rawrelay_http2_rst_stream_total HTTP/2 RST_STREAM frames sent\n"
-        "# TYPE rawrelay_http2_rst_stream_total counter\n"
-        "rawrelay_http2_rst_stream_total{worker=\"%d\"} %lu\n"
-        "\n"
-        "# HELP rawrelay_http2_goaway_total HTTP/2 GOAWAY frames sent\n"
-        "# TYPE rawrelay_http2_goaway_total counter\n"
-        "rawrelay_http2_goaway_total{worker=\"%d\"} %lu\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->h2_streams_total,
-        worker->worker_id, worker->h2_streams_active,
-        worker->worker_id, (unsigned long)worker->h2_rst_stream_total,
-        worker->worker_id, (unsigned long)worker->h2_goaway_sent);
-    METRICS_ADVANCE();
-
-    /* === Error Type Counters === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_errors_total Errors by type\n"
-        "# TYPE rawrelay_errors_total counter\n"
-        "rawrelay_errors_total{worker=\"%d\",type=\"timeout\"} %lu\n"
-        "rawrelay_errors_total{worker=\"%d\",type=\"parse_error\"} %lu\n"
-        "rawrelay_errors_total{worker=\"%d\",type=\"tls_error\"} %lu\n"
-        "\n",
-        worker->worker_id, (unsigned long)worker->errors_timeout,
-        worker->worker_id, (unsigned long)worker->errors_parse,
-        worker->worker_id, (unsigned long)worker->errors_tls);
-    METRICS_ADVANCE();
-
-    /* === Slot Metrics === */
-    n = snprintf(body + offset, remaining,
-        "# HELP rawrelay_slots_used Slots currently in use by tier\n"
-        "# TYPE rawrelay_slots_used gauge\n"
-        "rawrelay_slots_used{worker=\"%d\",tier=\"normal\"} %d\n"
-        "rawrelay_slots_used{worker=\"%d\",tier=\"large\"} %d\n"
-        "rawrelay_slots_used{worker=\"%d\",tier=\"huge\"} %d\n"
-        "\n"
-        "# HELP rawrelay_slots_max Maximum slots by tier\n"
-        "# TYPE rawrelay_slots_max gauge\n"
-        "rawrelay_slots_max{worker=\"%d\",tier=\"normal\"} %d\n"
-        "rawrelay_slots_max{worker=\"%d\",tier=\"large\"} %d\n"
-        "rawrelay_slots_max{worker=\"%d\",tier=\"huge\"} %d\n"
-        "\n"
-        "# HELP rawrelay_rate_limiter_entries Current rate limiter table size\n"
-        "# TYPE rawrelay_rate_limiter_entries gauge\n"
-        "rawrelay_rate_limiter_entries{worker=\"%d\"} %d\n",
-        worker->worker_id, slot_manager_current(&worker->slots, TIER_NORMAL),
-        worker->worker_id, slot_manager_current(&worker->slots, TIER_LARGE),
-        worker->worker_id, slot_manager_current(&worker->slots, TIER_HUGE),
-        worker->worker_id, slot_manager_max(&worker->slots, TIER_NORMAL),
-        worker->worker_id, slot_manager_max(&worker->slots, TIER_LARGE),
-        worker->worker_id, slot_manager_max(&worker->slots, TIER_HUGE),
-        worker->worker_id, rate_limiter_get_entry_count(&worker->rate_limiter));
-    METRICS_ADVANCE();
-
-    /* Ensure null termination */
-    body[offset] = '\0';
+    int body_len = generate_metrics_body(worker, body, sizeof(body));
 
     evbuffer_add_printf(output,
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n"
-        "Content-Length: %zu\r\n"
+        "Content-Length: %d\r\n"
         "Cache-Control: no-store\r\n"
         "X-Request-ID: %s\r\n"
         "Connection: close\r\n"
         "\r\n%s",
-        offset, conn->request_id, body);
+        body_len, conn->request_id, body);
 
     conn->response_status = 200;
-    conn->response_bytes = (int)offset;
+    conn->response_bytes = body_len;
     conn->state = CONN_STATE_CLOSING;
     bufferevent_enable(conn->bev, EV_WRITE);
-
-    #undef METRICS_ADVANCE
 }
 
 /*
@@ -1491,71 +1148,8 @@ static void connection_reset_for_keepalive(Connection *conn)
 }
 
 /*
- * Update latency histogram bucket based on duration in seconds.
- */
-static void update_latency_histogram(WorkerProcess *worker, double duration_sec)
-{
-    /* Increment appropriate bucket (cumulative histogram) */
-    if (duration_sec <= 0.001) worker->latency_bucket_1ms++;
-    if (duration_sec <= 0.005) worker->latency_bucket_5ms++;
-    if (duration_sec <= 0.01) worker->latency_bucket_10ms++;
-    if (duration_sec <= 0.05) worker->latency_bucket_50ms++;
-    if (duration_sec <= 0.1) worker->latency_bucket_100ms++;
-    if (duration_sec <= 0.5) worker->latency_bucket_500ms++;
-    if (duration_sec <= 1.0) worker->latency_bucket_1s++;
-    if (duration_sec <= 5.0) worker->latency_bucket_5s++;
-    worker->latency_bucket_inf++;  /* +Inf always increments */
-
-    worker->latency_sum_seconds += duration_sec;
-}
-
-/*
- * Update status code counters.
- */
-static void update_status_counters(WorkerProcess *worker, int status)
-{
-    /* Category counters */
-    if (status >= 200 && status < 300) {
-        worker->status_2xx++;
-    } else if (status >= 400 && status < 500) {
-        worker->status_4xx++;
-    } else if (status >= 500 && status < 600) {
-        worker->status_5xx++;
-    }
-
-    /* Specific status counters */
-    switch (status) {
-        case 200: worker->status_200++; break;
-        case 400: worker->status_400++; break;
-        case 404: worker->status_404++; break;
-        case 408: worker->status_408++; break;
-        case 429: worker->status_429++; break;
-        case 503: worker->status_503++; break;
-        default: break;
-    }
-}
-
-/*
- * Update method counters.
- */
-static void update_method_counters(WorkerProcess *worker, const char *method)
-{
-    if (!method || !method[0]) {
-        worker->method_other++;
-        return;
-    }
-
-    if (strcmp(method, "GET") == 0) {
-        worker->method_get++;
-    } else if (strcmp(method, "POST") == 0) {
-        worker->method_post++;
-    } else {
-        worker->method_other++;
-    }
-}
-
-/*
  * Log access entry for completed request.
+ * Uses shared counter/logging functions from endpoints.c.
  */
 static void log_request_complete(Connection *conn)
 {
@@ -1712,11 +1306,3 @@ void connection_send_error(Connection *conn, int status_code,
     connection_send_response(conn, status_code, status_text, body);
 }
 
-/*
- * Set up callbacks for a connection.
- * Used by TLS accept to reuse the same callback setup.
- */
-void connection_set_callbacks(Connection *conn)
-{
-    bufferevent_setcb(conn->bev, conn_read_cb, conn_write_cb, conn_event_cb, conn);
-}

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -113,6 +113,11 @@ int generate_health_body(WorkerProcess *worker, char *buf, size_t bufsize)
         max_fds,
         fd_usage_pct);
 
+    if (body_len < 0)
+        return 0;
+    if ((size_t)body_len >= bufsize)
+        body_len = (int)(bufsize - 1);
+
     return body_len;
 }
 

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -1,0 +1,579 @@
+#include "endpoints.h"
+#include "worker.h"
+#include "connection.h"
+#include "http2.h"
+#include "slot_manager.h"
+#include "rate_limiter.h"
+#include "tls.h"
+#include "hex.h"
+#include "log.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dirent.h>
+
+/*
+ * Get number of open file descriptors for this process.
+ */
+static int get_open_fds(void)
+{
+#ifdef __linux__
+    int count = 0;
+    DIR *dir = opendir("/proc/self/fd");
+    if (dir) {
+        struct dirent *entry;
+        while ((entry = readdir(dir)) != NULL) {
+            if (entry->d_name[0] != '.') {
+                count++;
+            }
+        }
+        closedir(dir);
+    }
+    return count;
+#else
+    return -1;  /* Not available on this platform */
+#endif
+}
+
+/*
+ * Get maximum file descriptors for this process.
+ */
+static int get_max_fds(void)
+{
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
+        return (int)rl.rlim_cur;
+    }
+    return -1;
+}
+
+/*
+ * Generate /health JSON response body.
+ */
+int generate_health_body(WorkerProcess *worker, char *buf, size_t bufsize)
+{
+    /* Calculate uptime */
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    long uptime_sec = now.tv_sec - worker->start_time.tv_sec;
+
+    /* Get FD counts */
+    int open_fds = get_open_fds();
+    int max_fds = get_max_fds();
+    double fd_usage_pct = (max_fds > 0) ? (100.0 * open_fds / max_fds) : 0.0;
+
+    /* Check if TLS is enabled and get cert expiry */
+    int tls_enabled = (worker->tls.ctx != NULL) ? 1 : 0;
+    time_t cert_expiry = tls_get_cert_expiry(&worker->tls);
+    int cert_days_remaining = 0;
+    int cert_warning = 0;
+    if (cert_expiry > 0) {
+        cert_days_remaining = (int)((cert_expiry - now.tv_sec) / 86400);
+        cert_warning = (cert_days_remaining < 30) ? 1 : 0;
+    }
+
+    int body_len = snprintf(buf, bufsize,
+        "{\"status\":\"healthy\","
+        "\"worker_id\":%d,"
+        "\"uptime_seconds\":%ld,"
+        "\"active_connections\":%d,"
+        "\"requests_processed\":%lu,"
+        "\"slots\":{"
+            "\"normal\":{\"used\":%d,\"max\":%d},"
+            "\"large\":{\"used\":%d,\"max\":%d},"
+            "\"huge\":{\"used\":%d,\"max\":%d}"
+        "},"
+        "\"rate_limiter_entries\":%d,"
+        "\"tls\":{\"enabled\":%s,\"cert_expires_in_days\":%d,\"cert_expiry_warning\":%s},"
+        "\"resources\":{"
+            "\"open_fds\":%d,"
+            "\"max_fds\":%d,"
+            "\"fd_usage_percent\":%.1f"
+        "}}",
+        worker->worker_id,
+        uptime_sec,
+        worker->active_connections,
+        (unsigned long)worker->requests_processed,
+        slot_manager_current(&worker->slots, TIER_NORMAL),
+        slot_manager_max(&worker->slots, TIER_NORMAL),
+        slot_manager_current(&worker->slots, TIER_LARGE),
+        slot_manager_max(&worker->slots, TIER_LARGE),
+        slot_manager_current(&worker->slots, TIER_HUGE),
+        slot_manager_max(&worker->slots, TIER_HUGE),
+        rate_limiter_get_entry_count(&worker->rate_limiter),
+        tls_enabled ? "true" : "false",
+        cert_days_remaining,
+        cert_warning ? "true" : "false",
+        open_fds,
+        max_fds,
+        fd_usage_pct);
+
+    return body_len;
+}
+
+/*
+ * Generate /metrics Prometheus response body.
+ */
+int generate_metrics_body(WorkerProcess *worker, char *buf, size_t bufsize)
+{
+    size_t offset = 0;
+    size_t remaining = bufsize - 1;  /* Reserve space for null terminator */
+    int n;
+
+    /* Helper macro to safely advance buffer position */
+    #define METRICS_ADVANCE() do { \
+        if (n > 0 && (size_t)n < remaining) { \
+            offset += (size_t)n; \
+            remaining -= (size_t)n; \
+        } else { \
+            remaining = 0; \
+        } \
+    } while(0)
+
+    /* Calculate uptime */
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    double uptime_sec = (now.tv_sec - worker->start_time.tv_sec) +
+                        (now.tv_usec - worker->start_time.tv_usec) / 1000000.0;
+
+    /* Get FD counts */
+    int open_fds = get_open_fds();
+    int max_fds = get_max_fds();
+
+    /* === Basic Counters === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_requests_total Total requests processed\n"
+        "# TYPE rawrelay_requests_total counter\n"
+        "rawrelay_requests_total{worker=\"%d\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_connections_accepted_total Total connections accepted\n"
+        "# TYPE rawrelay_connections_accepted_total counter\n"
+        "rawrelay_connections_accepted_total{worker=\"%d\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_connections_rejected_total Rejected connections by reason\n"
+        "# TYPE rawrelay_connections_rejected_total counter\n"
+        "rawrelay_connections_rejected_total{worker=\"%d\",reason=\"rate_limit\"} %lu\n"
+        "rawrelay_connections_rejected_total{worker=\"%d\",reason=\"slot_limit\"} %lu\n"
+        "rawrelay_connections_rejected_total{worker=\"%d\",reason=\"blocked\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_connections_allowlisted_total Connections that bypassed rate limiting\n"
+        "# TYPE rawrelay_connections_allowlisted_total counter\n"
+        "rawrelay_connections_allowlisted_total{worker=\"%d\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_active_connections Current active connections\n"
+        "# TYPE rawrelay_active_connections gauge\n"
+        "rawrelay_active_connections{worker=\"%d\"} %d\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->requests_processed,
+        worker->worker_id, (unsigned long)worker->connections_accepted,
+        worker->worker_id, (unsigned long)worker->connections_rejected_rate,
+        worker->worker_id, (unsigned long)worker->connections_rejected_slot,
+        worker->worker_id, (unsigned long)worker->connections_rejected_blocked,
+        worker->worker_id, (unsigned long)worker->connections_allowlisted,
+        worker->worker_id, worker->active_connections);
+    METRICS_ADVANCE();
+
+    /* === Request Latency Histogram === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_request_duration_seconds Request latency histogram\n"
+        "# TYPE rawrelay_request_duration_seconds histogram\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.001\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.005\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.01\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.05\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.1\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"0.5\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"1\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"5\"} %lu\n"
+        "rawrelay_request_duration_seconds_bucket{worker=\"%d\",le=\"+Inf\"} %lu\n"
+        "rawrelay_request_duration_seconds_sum{worker=\"%d\"} %.6f\n"
+        "rawrelay_request_duration_seconds_count{worker=\"%d\"} %lu\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->latency_bucket_1ms,
+        worker->worker_id, (unsigned long)worker->latency_bucket_5ms,
+        worker->worker_id, (unsigned long)worker->latency_bucket_10ms,
+        worker->worker_id, (unsigned long)worker->latency_bucket_50ms,
+        worker->worker_id, (unsigned long)worker->latency_bucket_100ms,
+        worker->worker_id, (unsigned long)worker->latency_bucket_500ms,
+        worker->worker_id, (unsigned long)worker->latency_bucket_1s,
+        worker->worker_id, (unsigned long)worker->latency_bucket_5s,
+        worker->worker_id, (unsigned long)worker->latency_bucket_inf,
+        worker->worker_id, worker->latency_sum_seconds,
+        worker->worker_id, (unsigned long)worker->latency_bucket_inf);
+    METRICS_ADVANCE();
+
+    /* === HTTP Status Code Counters === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_http_requests_total HTTP requests by status code\n"
+        "# TYPE rawrelay_http_requests_total counter\n"
+        "rawrelay_http_requests_total{worker=\"%d\",status=\"200\"} %lu\n"
+        "rawrelay_http_requests_total{worker=\"%d\",status=\"400\"} %lu\n"
+        "rawrelay_http_requests_total{worker=\"%d\",status=\"404\"} %lu\n"
+        "rawrelay_http_requests_total{worker=\"%d\",status=\"408\"} %lu\n"
+        "rawrelay_http_requests_total{worker=\"%d\",status=\"429\"} %lu\n"
+        "rawrelay_http_requests_total{worker=\"%d\",status=\"503\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_http_requests_by_class_total HTTP requests by status class\n"
+        "# TYPE rawrelay_http_requests_by_class_total counter\n"
+        "rawrelay_http_requests_by_class_total{worker=\"%d\",class=\"2xx\"} %lu\n"
+        "rawrelay_http_requests_by_class_total{worker=\"%d\",class=\"4xx\"} %lu\n"
+        "rawrelay_http_requests_by_class_total{worker=\"%d\",class=\"5xx\"} %lu\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->status_200,
+        worker->worker_id, (unsigned long)worker->status_400,
+        worker->worker_id, (unsigned long)worker->status_404,
+        worker->worker_id, (unsigned long)worker->status_408,
+        worker->worker_id, (unsigned long)worker->status_429,
+        worker->worker_id, (unsigned long)worker->status_503,
+        worker->worker_id, (unsigned long)worker->status_2xx,
+        worker->worker_id, (unsigned long)worker->status_4xx,
+        worker->worker_id, (unsigned long)worker->status_5xx);
+    METRICS_ADVANCE();
+
+    /* === Request Method Counters === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_requests_by_method_total HTTP requests by method\n"
+        "# TYPE rawrelay_requests_by_method_total counter\n"
+        "rawrelay_requests_by_method_total{worker=\"%d\",method=\"GET\"} %lu\n"
+        "rawrelay_requests_by_method_total{worker=\"%d\",method=\"POST\"} %lu\n"
+        "rawrelay_requests_by_method_total{worker=\"%d\",method=\"OTHER\"} %lu\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->method_get,
+        worker->worker_id, (unsigned long)worker->method_post,
+        worker->worker_id, (unsigned long)worker->method_other);
+    METRICS_ADVANCE();
+
+    /* === Process Info === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_process_start_time_seconds Unix timestamp of process start\n"
+        "# TYPE rawrelay_process_start_time_seconds gauge\n"
+        "rawrelay_process_start_time_seconds{worker=\"%d\"} %ld\n"
+        "\n"
+        "# HELP rawrelay_process_uptime_seconds Process uptime in seconds\n"
+        "# TYPE rawrelay_process_uptime_seconds gauge\n"
+        "rawrelay_process_uptime_seconds{worker=\"%d\"} %.3f\n"
+        "\n",
+        worker->worker_id, (long)worker->start_time.tv_sec,
+        worker->worker_id, uptime_sec);
+    METRICS_ADVANCE();
+
+    /* === File Descriptor Metrics === */
+    if (open_fds >= 0 && max_fds >= 0) {
+        n = snprintf(buf + offset, remaining,
+            "# HELP rawrelay_open_fds Current number of open file descriptors\n"
+            "# TYPE rawrelay_open_fds gauge\n"
+            "rawrelay_open_fds{worker=\"%d\"} %d\n"
+            "\n"
+            "# HELP rawrelay_max_fds Maximum file descriptors allowed\n"
+            "# TYPE rawrelay_max_fds gauge\n"
+            "rawrelay_max_fds{worker=\"%d\"} %d\n"
+            "\n",
+            worker->worker_id, open_fds,
+            worker->worker_id, max_fds);
+        METRICS_ADVANCE();
+    }
+
+    /* === TLS Metrics === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_tls_handshakes_total TLS handshakes by protocol version\n"
+        "# TYPE rawrelay_tls_handshakes_total counter\n"
+        "rawrelay_tls_handshakes_total{worker=\"%d\",protocol=\"TLSv1.2\"} %lu\n"
+        "rawrelay_tls_handshakes_total{worker=\"%d\",protocol=\"TLSv1.3\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_tls_handshake_errors_total TLS handshake errors\n"
+        "# TYPE rawrelay_tls_handshake_errors_total counter\n"
+        "rawrelay_tls_handshake_errors_total{worker=\"%d\"} %lu\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->tls_protocol_tls12,
+        worker->worker_id, (unsigned long)worker->tls_protocol_tls13,
+        worker->worker_id, (unsigned long)worker->tls_handshake_errors);
+    METRICS_ADVANCE();
+
+    /* === TLS Certificate Expiry === */
+    time_t cert_expiry = tls_get_cert_expiry(&worker->tls);
+    if (cert_expiry > 0) {
+        n = snprintf(buf + offset, remaining,
+            "# HELP rawrelay_tls_cert_expiry_timestamp_seconds Unix timestamp when certificate expires\n"
+            "# TYPE rawrelay_tls_cert_expiry_timestamp_seconds gauge\n"
+            "rawrelay_tls_cert_expiry_timestamp_seconds{worker=\"%d\"} %ld\n"
+            "\n",
+            worker->worker_id, (long)cert_expiry);
+        METRICS_ADVANCE();
+    }
+
+    /* === HTTP/2 Metrics === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_http2_streams_total Total HTTP/2 streams opened\n"
+        "# TYPE rawrelay_http2_streams_total counter\n"
+        "rawrelay_http2_streams_total{worker=\"%d\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_http2_streams_active Current active HTTP/2 streams\n"
+        "# TYPE rawrelay_http2_streams_active gauge\n"
+        "rawrelay_http2_streams_active{worker=\"%d\"} %d\n"
+        "\n"
+        "# HELP rawrelay_http2_rst_stream_total HTTP/2 RST_STREAM frames sent\n"
+        "# TYPE rawrelay_http2_rst_stream_total counter\n"
+        "rawrelay_http2_rst_stream_total{worker=\"%d\"} %lu\n"
+        "\n"
+        "# HELP rawrelay_http2_goaway_total HTTP/2 GOAWAY frames sent\n"
+        "# TYPE rawrelay_http2_goaway_total counter\n"
+        "rawrelay_http2_goaway_total{worker=\"%d\"} %lu\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->h2_streams_total,
+        worker->worker_id, worker->h2_streams_active,
+        worker->worker_id, (unsigned long)worker->h2_rst_stream_total,
+        worker->worker_id, (unsigned long)worker->h2_goaway_sent);
+    METRICS_ADVANCE();
+
+    /* === Error Type Counters === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_errors_total Errors by type\n"
+        "# TYPE rawrelay_errors_total counter\n"
+        "rawrelay_errors_total{worker=\"%d\",type=\"timeout\"} %lu\n"
+        "rawrelay_errors_total{worker=\"%d\",type=\"parse_error\"} %lu\n"
+        "rawrelay_errors_total{worker=\"%d\",type=\"tls_error\"} %lu\n"
+        "\n",
+        worker->worker_id, (unsigned long)worker->errors_timeout,
+        worker->worker_id, (unsigned long)worker->errors_parse,
+        worker->worker_id, (unsigned long)worker->errors_tls);
+    METRICS_ADVANCE();
+
+    /* === Slot Metrics === */
+    n = snprintf(buf + offset, remaining,
+        "# HELP rawrelay_slots_used Slots currently in use by tier\n"
+        "# TYPE rawrelay_slots_used gauge\n"
+        "rawrelay_slots_used{worker=\"%d\",tier=\"normal\"} %d\n"
+        "rawrelay_slots_used{worker=\"%d\",tier=\"large\"} %d\n"
+        "rawrelay_slots_used{worker=\"%d\",tier=\"huge\"} %d\n"
+        "\n"
+        "# HELP rawrelay_slots_max Maximum slots by tier\n"
+        "# TYPE rawrelay_slots_max gauge\n"
+        "rawrelay_slots_max{worker=\"%d\",tier=\"normal\"} %d\n"
+        "rawrelay_slots_max{worker=\"%d\",tier=\"large\"} %d\n"
+        "rawrelay_slots_max{worker=\"%d\",tier=\"huge\"} %d\n"
+        "\n"
+        "# HELP rawrelay_rate_limiter_entries Current rate limiter table size\n"
+        "# TYPE rawrelay_rate_limiter_entries gauge\n"
+        "rawrelay_rate_limiter_entries{worker=\"%d\"} %d\n",
+        worker->worker_id, slot_manager_current(&worker->slots, TIER_NORMAL),
+        worker->worker_id, slot_manager_current(&worker->slots, TIER_LARGE),
+        worker->worker_id, slot_manager_current(&worker->slots, TIER_HUGE),
+        worker->worker_id, slot_manager_max(&worker->slots, TIER_NORMAL),
+        worker->worker_id, slot_manager_max(&worker->slots, TIER_LARGE),
+        worker->worker_id, slot_manager_max(&worker->slots, TIER_HUGE),
+        worker->worker_id, rate_limiter_get_entry_count(&worker->rate_limiter));
+    METRICS_ADVANCE();
+
+    /* Ensure null termination */
+    buf[offset] = '\0';
+
+    #undef METRICS_ADVANCE
+
+    return (int)offset;
+}
+
+/*
+ * Serve ACME HTTP-01 challenge for HTTP/2.
+ */
+int serve_acme_challenge_h2(Connection *conn, int32_t stream_id,
+                            const char *path, size_t path_len,
+                            const char *request_id)
+{
+    WorkerProcess *worker = conn->worker;
+    const char *acme_dir = worker->config->acme_challenge_dir;
+
+    /* Extract token from path: /.well-known/acme-challenge/{token} */
+    const size_t prefix_len = 27;  /* ".well-known/acme-challenge/" */
+
+    if (path_len < prefix_len + 2 || path[0] != '/') {
+        log_warn("ACME H2: Invalid path format from %s", log_format_ip(conn->client_ip));
+        goto not_found;
+    }
+
+    const char *token = path + 1 + prefix_len;
+    size_t token_len = path_len - 1 - prefix_len;
+
+    /* Security: Reject path traversal attempts */
+    if (strstr(token, "..") || memchr(token, '/', token_len) || memchr(token, '\\', token_len)) {
+        log_warn("ACME H2: Path traversal attempt from %s: %s",
+                 log_format_ip(conn->client_ip), path);
+        goto not_found;
+    }
+
+    /* Security: Token should be base64url encoded (alphanumeric, -, _) */
+    for (size_t i = 0; i < token_len; i++) {
+        char c = token[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '-' || c == '_')) {
+            log_warn("ACME H2: Invalid token character from %s: '%c'",
+                     log_format_ip(conn->client_ip), c);
+            goto not_found;
+        }
+    }
+
+    /* Build full path to challenge file */
+    char filepath[512];
+    int n = snprintf(filepath, sizeof(filepath), "%s/%.*s",
+                     acme_dir, (int)token_len, token);
+    if (n < 0 || (size_t)n >= sizeof(filepath)) {
+        log_warn("ACME H2: Path too long from %s", log_format_ip(conn->client_ip));
+        goto not_found;
+    }
+
+    /* Open and read the challenge file */
+    int fd = open(filepath, O_RDONLY);
+    if (fd < 0) {
+        log_warn("ACME H2: Challenge file not found: %s (from %s)",
+                 filepath, log_format_ip(conn->client_ip));
+        goto not_found;
+    }
+
+    /* Get file size */
+    struct stat st;
+    if (fstat(fd, &st) < 0 || !S_ISREG(st.st_mode)) {
+        log_warn("ACME H2: Cannot stat challenge file: %s", filepath);
+        close(fd);
+        goto not_found;
+    }
+
+    /* Sanity check - ACME tokens are typically < 256 bytes */
+    if (st.st_size > 4096) {
+        log_warn("ACME H2: Challenge file too large: %s (%ld bytes)",
+                 filepath, (long)st.st_size);
+        close(fd);
+        goto not_found;
+    }
+
+    /* Read file content */
+    char content[4097];
+    ssize_t bytes_read = read(fd, content, st.st_size);
+    close(fd);
+
+    if (bytes_read < 0 || bytes_read != st.st_size) {
+        log_warn("ACME H2: Failed to read challenge file: %s", filepath);
+        goto not_found;
+    }
+
+    (void)request_id;  /* Available for future use in response headers */
+
+    log_info("ACME H2: Serving challenge for token %.*s to %s",
+             (int)token_len, token, log_format_ip(conn->client_ip));
+
+    h2_send_response(conn, stream_id, 200, "text/plain",
+                     (const unsigned char *)content, bytes_read);
+    return (int)bytes_read;
+
+not_found:
+    h2_send_response(conn, stream_id, 404, "text/plain",
+                     (const unsigned char *)"Not Found", 9);
+    return -1;
+}
+
+/*
+ * Validate hex characters in a path buffer.
+ * For paths > 64 chars, validates that all characters are valid hex.
+ * Allows "tx/" prefix.
+ */
+int validate_hex_path(const char *path, size_t path_len)
+{
+    /* Short paths (< 64 chars) could be /tx/txid or other routes - don't validate */
+    if (path_len < 64) {
+        return 0;
+    }
+
+    const char *p = path;
+    const char *end = path + path_len;
+
+    /* Allow 'tx/' prefix */
+    if (path_len > 3 && p[0] == 't' && p[1] == 'x' && p[2] == '/') {
+        p += 3;
+    }
+
+    /* Validate remaining characters as hex */
+    for (; p < end; p++) {
+        if (!is_hex_char((unsigned char)*p)) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Update latency histogram bucket based on duration in seconds.
+ */
+void update_latency_histogram(WorkerProcess *worker, double duration_sec)
+{
+    /* Increment appropriate bucket (cumulative histogram) */
+    if (duration_sec <= 0.001) worker->latency_bucket_1ms++;
+    if (duration_sec <= 0.005) worker->latency_bucket_5ms++;
+    if (duration_sec <= 0.01) worker->latency_bucket_10ms++;
+    if (duration_sec <= 0.05) worker->latency_bucket_50ms++;
+    if (duration_sec <= 0.1) worker->latency_bucket_100ms++;
+    if (duration_sec <= 0.5) worker->latency_bucket_500ms++;
+    if (duration_sec <= 1.0) worker->latency_bucket_1s++;
+    if (duration_sec <= 5.0) worker->latency_bucket_5s++;
+    worker->latency_bucket_inf++;  /* +Inf always increments */
+
+    worker->latency_sum_seconds += duration_sec;
+}
+
+/*
+ * Update status code counters.
+ */
+void update_status_counters(WorkerProcess *worker, int status)
+{
+    /* Category counters */
+    if (status >= 200 && status < 300) {
+        worker->status_2xx++;
+    } else if (status >= 400 && status < 500) {
+        worker->status_4xx++;
+    } else if (status >= 500 && status < 600) {
+        worker->status_5xx++;
+    }
+
+    /* Specific status counters */
+    switch (status) {
+        case 200: worker->status_200++; break;
+        case 400: worker->status_400++; break;
+        case 404: worker->status_404++; break;
+        case 408: worker->status_408++; break;
+        case 429: worker->status_429++; break;
+        case 503: worker->status_503++; break;
+        default: break;
+    }
+}
+
+/*
+ * Update method counters.
+ */
+void update_method_counters(WorkerProcess *worker, const char *method)
+{
+    if (!method || !method[0]) {
+        worker->method_other++;
+        return;
+    }
+
+    if (strcmp(method, "GET") == 0) {
+        worker->method_get++;
+    } else if (strcmp(method, "POST") == 0) {
+        worker->method_post++;
+    } else {
+        worker->method_other++;
+    }
+}
+
+/*
+ * Log access entry for a completed request.
+ */
+void log_request_access(const char *client_ip, const char *method,
+                        const char *path, int status, size_t bytes_sent,
+                        double duration_ms, const char *request_id)
+{
+    log_access(client_ip, method, path, status, bytes_sent, duration_ms, request_id);
+}

--- a/src/http2.c
+++ b/src/http2.c
@@ -4,16 +4,32 @@
 #include "router.h"
 #include "static_files.h"
 #include "slot_manager.h"
+#include "endpoints.h"
 #include "log.h"
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <sys/time.h>
 #include <nghttp2/nghttp2.h>
 #include <event2/buffer.h>
 
 /* Default HTTP/2 settings */
 #define H2_MAX_CONCURRENT_STREAMS 100
 #define H2_INITIAL_WINDOW_SIZE (1 << 20)  /* 1MB */
+
+/* Connection-level flow control window (16MB) */
+#define H2_CONNECTION_WINDOW_SIZE (16 * 1024 * 1024)
+
+/* Body source for response data provider */
+typedef struct {
+    unsigned char *data;  /* Owned copy of the body data */
+    size_t len;
+    size_t pos;
+} H2BodySource;
+
+/* Per-stream request ID counter (per-process) */
+static uint32_t h2_request_counter = 0;
 
 /* Forward declarations of nghttp2 callbacks */
 static ssize_t h2_send_callback(nghttp2_session *session,
@@ -39,13 +55,6 @@ static int h2_on_data_chunk_recv_callback(nghttp2_session *session,
                                           const uint8_t *data, size_t len,
                                           void *user_data);
 
-/* Forward declaration - body source for async response data */
-typedef struct {
-    unsigned char *data;  /* Owned copy of the body data */
-    size_t len;
-    size_t pos;
-} H2BodySource;
-
 /*
  * Create a new HTTP/2 stream.
  */
@@ -60,6 +69,13 @@ H2Stream *h2_stream_new(H2Connection *h2, int32_t stream_id)
     stream->state = H2_STREAM_OPEN;
     stream->tier = TIER_NORMAL;
     stream->slot_acquired = false;
+
+    /* Per-stream request tracking */
+    gettimeofday(&stream->start_time, NULL);
+    snprintf(stream->request_id, sizeof(stream->request_id), "%d-%lx-%xs%d",
+             h2->worker->worker_id,
+             (unsigned long)(stream->start_time.tv_sec * 1000000 + stream->start_time.tv_usec),
+             h2_request_counter++, stream_id);
 
     /* Add to list */
     stream->next = h2->streams;
@@ -156,6 +172,120 @@ static ssize_t h2_send_callback(nghttp2_session *session,
 }
 
 /*
+ * Downgrade HTTP/2 stream from large/huge tier to normal.
+ * Called after request is fully received to release expensive slots ASAP.
+ */
+static void h2_downgrade_tier_to_normal(H2Connection *h2, H2Stream *stream)
+{
+    if (!stream->slot_acquired || stream->tier == TIER_NORMAL) {
+        return;
+    }
+
+    /* Release the expensive slot */
+    slot_manager_release(&h2->worker->slots, stream->tier);
+
+    /* Acquire normal slot for response phase */
+    if (slot_manager_acquire(&h2->worker->slots, TIER_NORMAL)) {
+        log_debug("HTTP/2: Downgraded stream %d from %s to normal tier",
+                  stream->stream_id, tier_name(stream->tier));
+        stream->tier = TIER_NORMAL;
+    } else {
+        /* Can't get normal slot - try to re-acquire the expensive one */
+        if (!slot_manager_acquire(&h2->worker->slots, stream->tier)) {
+            stream->slot_acquired = false;
+        }
+    }
+}
+
+/*
+ * Process a complete HTTP/2 stream request.
+ * Unified routing handler called from both HEADERS and DATA END_STREAM paths.
+ */
+static void h2_process_stream_request(Connection *conn, H2Stream *stream)
+{
+    H2Connection *h2 = conn->h2;
+    WorkerProcess *worker = h2->worker;
+    RouteType route = route_request(stream->path, stream->path_len);
+    StaticFile *file;
+    int status_code = 200;
+    const char *content_type = "text/plain";
+    size_t body_len = 0;
+
+    switch (route) {
+        case ROUTE_HEALTH: {
+            char body[1024];
+            int len = generate_health_body(worker, body, sizeof(body));
+            status_code = 200;
+            content_type = "application/json";
+            body_len = len;
+            h2_send_response(conn, stream->stream_id, status_code, content_type,
+                             (const unsigned char *)body, body_len);
+            break;
+        }
+        case ROUTE_READY:
+            status_code = worker->draining ? 503 : 200;
+            h2_send_response(conn, stream->stream_id, status_code, "text/plain",
+                             (const unsigned char *)"", 0);
+            break;
+        case ROUTE_ALIVE:
+            status_code = 200;
+            h2_send_response(conn, stream->stream_id, 200, "text/plain",
+                             (const unsigned char *)"", 0);
+            break;
+        case ROUTE_METRICS: {
+            char body[8192];
+            int len = generate_metrics_body(worker, body, sizeof(body));
+            status_code = 200;
+            content_type = "text/plain; version=0.0.4; charset=utf-8";
+            body_len = len;
+            h2_send_response(conn, stream->stream_id, status_code, content_type,
+                             (const unsigned char *)body, body_len);
+            break;
+        }
+        case ROUTE_ACME_CHALLENGE: {
+            int acme_len = serve_acme_challenge_h2(conn, stream->stream_id,
+                                        stream->path, stream->path_len,
+                                        stream->request_id);
+            if (acme_len > 0) {
+                status_code = 200;
+                body_len = acme_len;
+            } else {
+                status_code = 404;
+                body_len = 9;  /* "Not Found" */
+            }
+            break;
+        }
+        case ROUTE_BROADCAST:
+            file = &worker->static_files.broadcast;
+            body_len = file->length;
+            h2_send_response(conn, stream->stream_id, status_code, file->content_type,
+                             (const unsigned char *)file->content, file->length);
+            break;
+        case ROUTE_RESULT:
+            file = &worker->static_files.result;
+            body_len = file->length;
+            h2_send_response(conn, stream->stream_id, status_code, file->content_type,
+                             (const unsigned char *)file->content, file->length);
+            break;
+        case ROUTE_ERROR:
+        default:
+            file = &worker->static_files.error;
+            status_code = 400;
+            body_len = file->length;
+            h2_send_response(conn, stream->stream_id, status_code, file->content_type,
+                             (const unsigned char *)file->content, file->length);
+            break;
+    }
+
+    /* Track response in stream */
+    stream->response_status = status_code;
+    stream->response_bytes = body_len;
+
+    /* Tier downgrade: release expensive slot ASAP after request is processed */
+    h2_downgrade_tier_to_normal(h2, stream);
+}
+
+/*
  * Frame received callback.
  */
 static int h2_on_frame_recv_callback(nghttp2_session *session,
@@ -168,126 +298,23 @@ static int h2_on_frame_recv_callback(nghttp2_session *session,
 
     switch (frame->hd.type) {
         case NGHTTP2_HEADERS:
-            /* Headers frame with END_STREAM - request complete */
+            /* Headers frame with END_STREAM - request complete (no body) */
             if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
                 H2Stream *stream = h2_stream_find(h2, frame->hd.stream_id);
                 if (stream) {
                     stream->state = H2_STREAM_HALF_CLOSED_REMOTE;
-                    /* Process the request */
-                    /* Route and respond */
-                    WorkerProcess *worker = h2->worker;
-                    RouteType route = route_request(stream->path, stream->path_len);
-                    StaticFile *file;
-                    int status_code = 200;
-
-                    switch (route) {
-                        case ROUTE_HEALTH: {
-                            char body[512];
-                            int body_len = snprintf(body, sizeof(body),
-                                "{\"status\":\"healthy\",\"worker_id\":%d,\"protocol\":\"h2\"}",
-                                worker->worker_id);
-                            h2_send_response(conn, frame->hd.stream_id, 200, "application/json",
-                                             (const unsigned char *)body, body_len);
-                            break;
-                        }
-                        case ROUTE_READY:
-                            h2_send_response(conn, frame->hd.stream_id,
-                                             worker->draining ? 503 : 200, "text/plain",
-                                             (const unsigned char *)"", 0);
-                            break;
-                        case ROUTE_ALIVE:
-                            h2_send_response(conn, frame->hd.stream_id, 200, "text/plain",
-                                             (const unsigned char *)"", 0);
-                            break;
-                        case ROUTE_METRICS: {
-                            char body[256];
-                            int body_len = snprintf(body, sizeof(body),
-                                "# HTTP/2 metrics\nrawrelay_h2_active{worker=\"%d\"} 1\n",
-                                worker->worker_id);
-                            h2_send_response(conn, frame->hd.stream_id, 200, "text/plain",
-                                             (const unsigned char *)body, body_len);
-                            break;
-                        }
-                        case ROUTE_BROADCAST:
-                            file = &worker->static_files.broadcast;
-                            h2_send_response(conn, frame->hd.stream_id, status_code, file->content_type,
-                                             (const unsigned char *)file->content, file->length);
-                            break;
-                        case ROUTE_RESULT:
-                            file = &worker->static_files.result;
-                            h2_send_response(conn, frame->hd.stream_id, status_code, file->content_type,
-                                             (const unsigned char *)file->content, file->length);
-                            break;
-                        case ROUTE_ERROR:
-                        default:
-                            file = &worker->static_files.error;
-                            status_code = 400;
-                            h2_send_response(conn, frame->hd.stream_id, status_code, file->content_type,
-                                             (const unsigned char *)file->content, file->length);
-                            break;
-                    }
+                    h2_process_stream_request(conn, stream);
                 }
             }
             break;
 
         case NGHTTP2_DATA:
-            /* Data frame with END_STREAM */
+            /* Data frame with END_STREAM - request with body complete */
             if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
                 H2Stream *stream = h2_stream_find(h2, frame->hd.stream_id);
                 if (stream) {
                     stream->state = H2_STREAM_HALF_CLOSED_REMOTE;
-                    /* Process with body - similar to HEADERS handler */
-                    WorkerProcess *worker = h2->worker;
-                    RouteType route = route_request(stream->path, stream->path_len);
-                    StaticFile *file;
-                    int status_code = 200;
-
-                    switch (route) {
-                        case ROUTE_HEALTH: {
-                            char body[512];
-                            int body_len = snprintf(body, sizeof(body),
-                                "{\"status\":\"healthy\",\"worker_id\":%d,\"protocol\":\"h2\"}",
-                                worker->worker_id);
-                            h2_send_response(conn, frame->hd.stream_id, 200, "application/json",
-                                             (const unsigned char *)body, body_len);
-                            break;
-                        }
-                        case ROUTE_READY:
-                            h2_send_response(conn, frame->hd.stream_id,
-                                             worker->draining ? 503 : 200, "text/plain",
-                                             (const unsigned char *)"", 0);
-                            break;
-                        case ROUTE_ALIVE:
-                            h2_send_response(conn, frame->hd.stream_id, 200, "text/plain",
-                                             (const unsigned char *)"", 0);
-                            break;
-                        case ROUTE_METRICS: {
-                            char body[256];
-                            int body_len = snprintf(body, sizeof(body),
-                                "# HTTP/2 metrics\nrawrelay_h2_active{worker=\"%d\"} 1\n",
-                                worker->worker_id);
-                            h2_send_response(conn, frame->hd.stream_id, 200, "text/plain",
-                                             (const unsigned char *)body, body_len);
-                            break;
-                        }
-                        case ROUTE_BROADCAST:
-                            file = &worker->static_files.broadcast;
-                            h2_send_response(conn, frame->hd.stream_id, status_code, file->content_type,
-                                             (const unsigned char *)file->content, file->length);
-                            break;
-                        case ROUTE_RESULT:
-                            file = &worker->static_files.result;
-                            h2_send_response(conn, frame->hd.stream_id, status_code, file->content_type,
-                                             (const unsigned char *)file->content, file->length);
-                            break;
-                        case ROUTE_ERROR:
-                        default:
-                            file = &worker->static_files.error;
-                            status_code = 400;
-                            h2_send_response(conn, frame->hd.stream_id, status_code, file->content_type,
-                                             (const unsigned char *)file->content, file->length);
-                            break;
-                    }
+                    h2_process_stream_request(conn, stream);
                 }
             }
             break;
@@ -300,7 +327,7 @@ static int h2_on_frame_recv_callback(nghttp2_session *session,
 }
 
 /*
- * Stream close callback - release slot.
+ * Stream close callback - log access and release slot.
  */
 static int h2_on_stream_close_callback(nghttp2_session *session,
                                        int32_t stream_id,
@@ -314,6 +341,28 @@ static int h2_on_stream_close_callback(nghttp2_session *session,
 
     H2Stream *stream = h2_stream_find(h2, stream_id);
     if (stream) {
+        /* Access logging for HTTP/2 streams */
+        if (stream->response_status > 0) {
+            WorkerProcess *worker = h2->worker;
+            struct timeval now;
+            gettimeofday(&now, NULL);
+            double duration_ms = (now.tv_sec - stream->start_time.tv_sec) * 1000.0 +
+                                 (now.tv_usec - stream->start_time.tv_usec) / 1000.0;
+            double duration_sec = duration_ms / 1000.0;
+
+            update_latency_histogram(worker, duration_sec);
+            update_status_counters(worker, stream->response_status);
+            update_method_counters(worker, stream->method);
+
+            log_request_access(conn->client_ip,
+                               stream->method ? stream->method : "???",
+                               stream->path ? stream->path : "/",
+                               stream->response_status,
+                               stream->response_bytes,
+                               duration_ms,
+                               stream->request_id);
+        }
+
         stream->state = H2_STREAM_CLOSED;
         h2_stream_free(h2, stream);
     }
@@ -360,7 +409,7 @@ static int h2_on_begin_headers_callback(nghttp2_session *session,
 }
 
 /*
- * Header callback - process :path to determine tier.
+ * Header callback - process :path to determine tier and validate hex.
  * This is where we know the request size BEFORE processing!
  */
 static int h2_on_header_callback(nghttp2_session *session,
@@ -371,7 +420,6 @@ static int h2_on_header_callback(nghttp2_session *session,
 {
     Connection *conn = (Connection *)user_data;
     H2Connection *h2 = conn->h2;
-    (void)session;
     (void)flags;
 
     if (frame->hd.type != NGHTTP2_HEADERS) {
@@ -389,6 +437,23 @@ static int h2_on_header_callback(nghttp2_session *session,
     } else if (namelen == 5 && memcmp(name, ":path", 5) == 0) {
         stream->path = strndup((const char *)value, valuelen);
         stream->path_len = valuelen;
+
+        /* Hex path validation for long paths (same as HTTP/1.1 validate_path_early) */
+        if (stream->path && stream->path_len > 1) {
+            /* Skip leading slash for validation */
+            const char *path_content = stream->path + 1;
+            size_t content_len = stream->path_len - 1;
+
+            if (validate_hex_path(path_content, content_len) < 0) {
+                log_warn("HTTP/2: Invalid hex in path from %s on stream %d",
+                         log_format_ip(conn->client_ip), stream->stream_id);
+                nghttp2_submit_rst_stream(session, NGHTTP2_FLAG_NONE,
+                                          stream->stream_id, NGHTTP2_REFUSED_STREAM);
+                h2->worker->h2_rst_stream_total++;
+                h2->worker->errors_parse++;
+                return 0;
+            }
+        }
 
         /* THE KEY WIN: Size known BEFORE allocating! */
         /* Try to promote tier based on path length */
@@ -470,9 +535,48 @@ int h2_connection_init(Connection *conn)
     nghttp2_session_callbacks_set_on_header_callback(callbacks, h2_on_header_callback);
     nghttp2_session_callbacks_set_on_data_chunk_recv_callback(callbacks, h2_on_data_chunk_recv_callback);
 
-    /* Create server session */
-    int rv = nghttp2_session_server_new(&h2->session, callbacks, conn);
+    /* === nghttp2 Security Hardening === */
+    nghttp2_option *option;
+    if (nghttp2_option_new(&option) != 0) {
+        nghttp2_session_callbacks_del(callbacks);
+        free(h2);
+        return -1;
+    }
+
+    /* CVE-2023-44487: Rapid Reset attack protection.
+     * Limit stream reset rate to 1000 resets per 33 second window. */
+#ifdef NGHTTP2_VERSION_NUM
+#if NGHTTP2_VERSION_NUM >= 0x013b00  /* 1.59.0 */
+    nghttp2_option_set_stream_reset_rate_limit(option, 1000, 33);
+#endif
+#endif
+
+    /* CVE-2024-28182: CONTINUATION flood protection.
+     * Limit CONTINUATION frames per HEADERS sequence. */
+#ifdef NGHTTP2_VERSION_NUM
+#if NGHTTP2_VERSION_NUM >= 0x013c00  /* 1.60.0 */
+    nghttp2_option_set_max_continuations(option, 8);
+#endif
+#endif
+
+    /* SETTINGS flood protection */
+#ifdef NGHTTP2_VERSION_NUM
+#if NGHTTP2_VERSION_NUM >= 0x012600  /* 1.38.0 */
+    nghttp2_option_set_max_settings(option, 32);
+#endif
+#endif
+
+    /* Ping/SETTINGS ACK flood protection */
+#ifdef NGHTTP2_VERSION_NUM
+#if NGHTTP2_VERSION_NUM >= 0x012600  /* 1.38.0 */
+    nghttp2_option_set_max_outbound_ack(option, 1000);
+#endif
+#endif
+
+    /* Create server session with security options */
+    int rv = nghttp2_session_server_new2(&h2->session, callbacks, conn, option);
     nghttp2_session_callbacks_del(callbacks);
+    nghttp2_option_del(option);
 
     if (rv != 0) {
         log_error("Failed to create nghttp2 session: %s", nghttp2_strerror(rv));
@@ -480,10 +584,12 @@ int h2_connection_init(Connection *conn)
         return -1;
     }
 
-    /* Send SETTINGS frame */
+    /* Send SETTINGS frame with security-relevant settings */
     nghttp2_settings_entry settings[] = {
         {NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, h2->max_concurrent_streams},
-        {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, h2->initial_window_size}
+        {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, h2->initial_window_size},
+        {NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, (uint32_t)(conn->worker->config->max_buffer_size + 4096)},
+        {NGHTTP2_SETTINGS_ENABLE_PUSH, 0}
     };
 
     rv = nghttp2_submit_settings(h2->session, NGHTTP2_FLAG_NONE,
@@ -493,6 +599,17 @@ int h2_connection_init(Connection *conn)
         nghttp2_session_del(h2->session);
         free(h2);
         return -1;
+    }
+
+    /* Set connection-level flow control window.
+     * Prevents the connection window from bottlenecking when multiple
+     * streams are active with large responses. */
+    rv = nghttp2_session_set_local_window_size(h2->session, NGHTTP2_FLAG_NONE,
+                                                0, H2_CONNECTION_WINDOW_SIZE);
+    if (rv != 0) {
+        log_debug("HTTP/2: Failed to set connection window size: %s",
+                  nghttp2_strerror(rv));
+        /* Non-fatal - continue with default window */
     }
 
     conn->h2 = h2;
@@ -592,7 +709,7 @@ static ssize_t h2_body_read_callback(nghttp2_session *session,
 }
 
 /*
- * Send HTTP/2 response.
+ * Send HTTP/2 response with full headers.
  */
 int h2_send_response(Connection *conn, int32_t stream_id,
                      int status_code, const char *content_type,
@@ -611,11 +728,37 @@ int h2_send_response(Connection *conn, int32_t stream_id,
     char content_length_str[32];
     snprintf(content_length_str, sizeof(content_length_str), "%zu", body_len);
 
+    /* Determine cache-control based on route */
+    const char *cache_control = "no-store";
+    int cache_max_age = conn->worker->config->cache_max_age;
+    char cache_control_buf[64];
+    /* Static file routes use configurable caching */
+    if (status_code == 200 && cache_max_age > 0 &&
+        strcmp(content_type, "text/html; charset=utf-8") == 0) {
+        snprintf(cache_control_buf, sizeof(cache_control_buf),
+                 "public, max-age=%d", cache_max_age);
+        cache_control = cache_control_buf;
+    }
+
+    /* Get per-stream request ID */
+    const char *request_id = "";
+    H2Stream *stream = h2_stream_find(h2, stream_id);
+    if (stream) {
+        request_id = stream->request_id;
+    }
+
     /* Headers */
     nghttp2_nv headers[] = {
-        {(uint8_t *)":status", (uint8_t *)status_str, 7, strlen(status_str), NGHTTP2_NV_FLAG_NONE},
-        {(uint8_t *)"content-type", (uint8_t *)content_type, 12, strlen(content_type), NGHTTP2_NV_FLAG_NONE},
-        {(uint8_t *)"content-length", (uint8_t *)content_length_str, 14, strlen(content_length_str), NGHTTP2_NV_FLAG_NONE}
+        {(uint8_t *)":status", (uint8_t *)status_str,
+         7, strlen(status_str), NGHTTP2_NV_FLAG_NONE},
+        {(uint8_t *)"content-type", (uint8_t *)content_type,
+         12, strlen(content_type), NGHTTP2_NV_FLAG_NONE},
+        {(uint8_t *)"content-length", (uint8_t *)content_length_str,
+         14, strlen(content_length_str), NGHTTP2_NV_FLAG_NONE},
+        {(uint8_t *)"x-request-id", (uint8_t *)request_id,
+         12, strlen(request_id), NGHTTP2_NV_FLAG_NONE},
+        {(uint8_t *)"cache-control", (uint8_t *)cache_control,
+         13, strlen(cache_control), NGHTTP2_NV_FLAG_NONE}
     };
 
     /* Data provider for body - copy body data so it survives async send.
@@ -653,7 +796,6 @@ int h2_send_response(Connection *conn, int32_t stream_id,
     }
 
     /* Track body_source in stream for proper cleanup */
-    H2Stream *stream = h2_stream_find(h2, stream_id);
     if (stream) {
         /* Free any previous body_source (shouldn't happen, but be safe) */
         if (stream->body_source) {
@@ -663,31 +805,6 @@ int h2_send_response(Connection *conn, int32_t stream_id,
         }
         stream->body_source = body_source;
     }
-
-    return h2_send_pending(conn);
-}
-
-/*
- * UNHOOKED: Not called from production or test code.
- * The one place that sends RST_STREAM (h2_on_header_callback, line ~387)
- * calls nghttp2_submit_rst_stream() directly instead of using this wrapper.
- */
-int h2_send_error(Connection *conn, int32_t stream_id, uint32_t error_code)
-{
-    H2Connection *h2 = conn->h2;
-    if (!h2 || !h2->session) {
-        return -1;
-    }
-
-    int rv = nghttp2_submit_rst_stream(h2->session, NGHTTP2_FLAG_NONE,
-                                        stream_id, error_code);
-    if (rv != 0) {
-        log_error("HTTP/2: Failed to submit RST_STREAM: %s", nghttp2_strerror(rv));
-        return -1;
-    }
-
-    /* Track RST_STREAM metrics */
-    h2->worker->h2_rst_stream_total++;
 
     return h2_send_pending(conn);
 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -142,11 +142,41 @@ int tls_context_init(TLSContext *tls, const Config *config)
     SSL_CTX_set_session_cache_mode(tls->ctx, SSL_SESS_CACHE_SERVER);
     SSL_CTX_set_session_id_context(tls->ctx, (const unsigned char *)"rawrelay", 8);
 
-    /* Disable TLS compression (CRIME attack mitigation) */
-    SSL_CTX_set_options(tls->ctx, SSL_OP_NO_COMPRESSION);
+    /* TLS security hardening - defense-in-depth flags.
+     * SSL_CTX_set_min_proto_version(TLS1_2_VERSION) already disables
+     * SSLv2/SSLv3/TLS1.0/1.1, but explicit flags guard against
+     * implementation bugs. */
+    SSL_CTX_set_options(tls->ctx,
+        SSL_OP_NO_SSLv2 |
+        SSL_OP_NO_SSLv3 |
+        SSL_OP_NO_COMPRESSION |
+        SSL_OP_CIPHER_SERVER_PREFERENCE
+#ifdef SSL_OP_SINGLE_DH_USE
+        | SSL_OP_SINGLE_DH_USE
+#endif
+    );
 
-    /* Enable server preference for cipher ordering */
-    SSL_CTX_set_options(tls->ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+    /* Disable TLS renegotiation (CVE-2009-3555 and similar attacks) */
+#ifdef SSL_OP_NO_RENEGOTIATION
+    SSL_CTX_set_options(tls->ctx, SSL_OP_NO_RENEGOTIATION);
+#endif
+
+    /* Treat unexpected EOF from peer as normal close (OpenSSL 3.x) */
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+    SSL_CTX_set_options(tls->ctx, SSL_OP_IGNORE_UNEXPECTED_EOF);
+#endif
+
+    /* Explicit cipher list - Mozilla Intermediate profile.
+     * Ensures only strong ciphers with forward secrecy. */
+    SSL_CTX_set_cipher_list(tls->ctx,
+        "ECDHE-ECDSA-AES128-GCM-SHA256:"
+        "ECDHE-RSA-AES128-GCM-SHA256:"
+        "ECDHE-ECDSA-AES256-GCM-SHA384:"
+        "ECDHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-CHACHA20-POLY1305:"
+        "ECDHE-RSA-CHACHA20-POLY1305:"
+        "DHE-RSA-AES128-GCM-SHA256:"
+        "DHE-RSA-AES256-GCM-SHA384");
 
     log_info("TLS context initialized (HTTP/2: %s)",
              tls->http2_enabled ? "enabled" : "disabled");
@@ -294,9 +324,35 @@ int tls_context_reload(TLSContext *tls, const Config *config)
     SSL_CTX_set_session_cache_mode(new_ctx, SSL_SESS_CACHE_SERVER);
     SSL_CTX_set_session_id_context(new_ctx, (const unsigned char *)"rawrelay", 8);
 
-    /* Disable TLS compression and enable server cipher preference */
-    SSL_CTX_set_options(new_ctx, SSL_OP_NO_COMPRESSION);
-    SSL_CTX_set_options(new_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+    /* TLS security hardening - same flags as tls_context_init() */
+    SSL_CTX_set_options(new_ctx,
+        SSL_OP_NO_SSLv2 |
+        SSL_OP_NO_SSLv3 |
+        SSL_OP_NO_COMPRESSION |
+        SSL_OP_CIPHER_SERVER_PREFERENCE
+#ifdef SSL_OP_SINGLE_DH_USE
+        | SSL_OP_SINGLE_DH_USE
+#endif
+    );
+
+#ifdef SSL_OP_NO_RENEGOTIATION
+    SSL_CTX_set_options(new_ctx, SSL_OP_NO_RENEGOTIATION);
+#endif
+
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+    SSL_CTX_set_options(new_ctx, SSL_OP_IGNORE_UNEXPECTED_EOF);
+#endif
+
+    /* Mozilla Intermediate cipher list */
+    SSL_CTX_set_cipher_list(new_ctx,
+        "ECDHE-ECDSA-AES128-GCM-SHA256:"
+        "ECDHE-RSA-AES128-GCM-SHA256:"
+        "ECDHE-ECDSA-AES256-GCM-SHA384:"
+        "ECDHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-CHACHA20-POLY1305:"
+        "ECDHE-RSA-CHACHA20-POLY1305:"
+        "DHE-RSA-AES128-GCM-SHA256:"
+        "DHE-RSA-AES256-GCM-SHA384");
 
     /* Atomically swap the context */
     SSL_CTX *old_ctx = tls->ctx;


### PR DESCRIPTION
## Summary

- **Endpoint extraction**: Move health body generator, metrics body generator, latency/status/method counter updates, hex path validation, and ACME challenge handler into shared `endpoints.c/h` — eliminates duplication between HTTP/1.1 and HTTP/2 code paths
- **HTTP/2 endpoint parity**: All endpoints (`/health`, `/ready`, `/alive`, `/metrics`, ACME challenges, static files) now serve identical content over HTTP/2 with proper headers (X-Request-ID, Cache-Control, Content-Type)
- **Per-stream request tracking**: Each HTTP/2 stream gets a unique request ID, start time, and response status/size tracking for access logging
- **nghttp2 CVE protections**: Rapid Reset (CVE-2023-44487), CONTINUATION flood (CVE-2024-28182), SETTINGS flood, and ping/ACK flood limits — all ifdef-guarded by nghttp2 version
- **TLS hardening**: Mozilla Intermediate cipher list, `SSL_OP_NO_RENEGOTIATION`, defense-in-depth flags (`NO_SSLv2/3`, `SINGLE_DH_USE`, `IGNORE_UNEXPECTED_EOF`), consistent between `tls_context_init()` and `tls_context_reload()`
- **Dead code removal**: `connection_set_callbacks()`, `h2_send_error()` (both unhooked)
- **Unified H2 routing**: `h2_process_stream_request()` handles both HEADERS and DATA END_STREAM paths, replacing duplicated switch blocks

## Files changed

| File | Change |
|------|--------|
| `src/endpoints.c` | **NEW** — shared body generators, counter updates, hex validation, ACME H2 |
| `include/endpoints.h` | **NEW** — public API for endpoints |
| `src/http2.c` | H2 routing, per-stream IDs, CVE protections, response headers |
| `src/connection.c` | Extract endpoint logic to endpoints.c, remove dead code |
| `include/http2.h` | Per-stream tracking fields in H2Stream |
| `include/connection.h` | Remove dead `connection_set_callbacks()` declaration |
| `src/tls.c` | Mozilla ciphers, hardening flags in init + reload |
| `Makefile` | Add `endpoints.c` to build |

## Test plan

- [x] `make` compiles clean with `-Wall -Wextra -Werror` (gcc, Linux)
- [x] `make test` — 17/17 unit tests pass
- [x] HTTP/2 integration tests — 24/24 pass (ALPN, endpoint parity, ACME, TLS hardening, metrics, multiplexing)
- [ ] CI: all build matrix jobs (Linux + macOS, gcc + clang, sanitizers, static analysis)