### PR TITLE
Switch duration timing to clock_gettime(CLOCK_MONOTONIC)

### DIFF
--- a/include/connection.h
+++ b/include/connection.h
@@ -90,10 +90,10 @@ typedef struct Connection {
     struct H2Connection *h2;     /* HTTP/2 session state */
 
     /* Timing */
-    struct timeval start_time;
+    struct timespec start_time;
 
     /* Slowloris protection - throughput tracking */
-    struct timeval last_progress_time;  /* Last time we checked throughput */
+    struct timespec last_progress_time;  /* Last time we checked throughput */
     size_t bytes_at_last_check;         /* Bytes received at last check */
 
     /* Request tracking (Phase 5) */

--- a/include/http2.h
+++ b/include/http2.h
@@ -51,7 +51,7 @@ typedef struct H2Stream {
 
     /* Per-stream request tracking */
     char request_id[32];           /* Per-stream request ID */
-    struct timeval start_time;     /* Stream start time for latency */
+    struct timespec start_time;    /* Stream start time for latency */
     int response_status;           /* HTTP status code sent */
     size_t response_bytes;         /* Response body size */
 

--- a/include/worker.h
+++ b/include/worker.h
@@ -72,7 +72,8 @@ typedef struct WorkerProcess {
     int active_connections;
 
     /* Process info (Phase 5 metrics) */
-    struct timeval start_time;         /* Worker start time for uptime */
+    struct timespec start_time;        /* Worker start time for uptime (monotonic) */
+    time_t start_wallclock;            /* Wall-clock epoch for Prometheus metrics */
 
     /* Request latency histogram (Phase 5)
      * Buckets: 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s, +Inf */

--- a/src/rate_limiter.c
+++ b/src/rate_limiter.c
@@ -10,9 +10,9 @@
  */
 static double get_time_precise(void)
 {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return tv.tv_sec + tv.tv_usec / 1000000.0;
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec / 1e9;
 }
 
 /* Hash table size (prime for better distribution) */

--- a/src/worker.c
+++ b/src/worker.c
@@ -571,7 +571,8 @@ void worker_main(int worker_id, Config *config)
     worker.cpu_core = worker_id % get_num_cpus();
 
     /* Record start time for uptime metric */
-    gettimeofday(&worker.start_time, NULL);
+    clock_gettime(CLOCK_MONOTONIC, &worker.start_time);
+    worker.start_wallclock = time(NULL);
 
     /* Pin to CPU */
     if (pin_to_cpu(worker.cpu_core) == 0) {


### PR DESCRIPTION
## Summary

- Replace all `gettimeofday()` duration measurements with `clock_gettime(CLOCK_MONOTONIC)`, making elapsed-time calculations immune to NTP time jumps
- Add `start_wallclock` field to `WorkerProcess` for Prometheus `process_start_time_seconds` (needs wall-clock epoch)
- Preserve `gettimeofday()` in log.c (wall-clock timestamps) and libevent APIs (require `struct timeval`)

## Changes

| File | What changed |
|------|-------------|
| `include/connection.h` | `start_time`, `last_progress_time`: `timeval` → `timespec` |
| `include/http2.h` | `start_time`: `timeval` → `timespec` |
| `include/worker.h` | `start_time`: `timeval` → `timespec`, add `start_wallclock` |
| `src/connection.c` | 4 init sites + 5 duration calcs (`tv_usec` → `tv_nsec`) |
| `src/http2.c` | 1 init site + 2 duration calcs |
| `src/worker.c` | 1 init site + `start_wallclock = time(NULL)` |
| `src/endpoints.c` | 2 uptime calcs, wallclock metric, cert expiry fix |
| `src/rate_limiter.c` | `get_time_precise()` → `CLOCK_MONOTONIC` |

## What stays unchanged
- `log.c` — wall-clock timestamps for logs
- `connection.c: read_timeout` — libevent `bufferevent_set_timeouts()` requires `struct timeval`
- `worker.c: cleanup_interval` — libevent `event_add()` requires `struct timeval`
- `rpc.c` — socket timeouts and libevent timers require `struct timeval`

## Test plan
- [x] `make clean && make` — zero warnings with `-Wall -Wextra -Werror`
- [x] `make test` — 17/17 unit tests
- [x] H2 integration tests — 24/24
- [x] HTTP/1.1 integration tests — 16/16
- [x] Timing unit tests — 19/19 (nsec borrow, boundary cases, request ID seed)
- [x] Timing integration tests — 11/11 (wall-clock epoch validation, uptime plausibility, latency non-negative, rate limiter under monotonic clock, H2 stream timing)