### PR TITLE
Visual parity and client-side network selector

### DIFF
--- a/include/static_files.h
+++ b/include/static_files.h
@@ -30,13 +30,11 @@ typedef struct StaticFiles {
 
 /*
  * Load all static files from a directory.
- * Files must exist: broadcast.html, result.html, error.html
- *
- * For non-mainnet chains, injects a network banner into HTML files.
+ * Files are served as-is with no modification.
  *
  * @param files  Pointer to StaticFiles struct to populate
  * @param dir    Directory path (e.g., "./static")
- * @param config Config with chain setting for banner injection
+ * @param config Config (reserved for future use)
  * @return 0 on success, -1 on error
  */
 int static_files_load(StaticFiles *files, const char *dir, const Config *config);

--- a/src/static_files.c
+++ b/src/static_files.c
@@ -34,10 +34,7 @@ static const char *get_banner_html(BitcoinChain chain)
                    "SIGNET - Coins have no value"
                    "</div>";
         case CHAIN_REGTEST:
-            return "<script>window.__NETWORK__='regtest'</script>"
-                   "<div class=\"network-banner network-banner-regtest\">"
-                   "REGTEST - Local test network"
-                   "</div>";
+            return "<script>window.__NETWORK__='regtest'</script>";
         case CHAIN_MAINNET:
         default:
             return "<script>window.__NETWORK__='mainnet'</script>";

--- a/src/static_files.c
+++ b/src/static_files.c
@@ -1,5 +1,4 @@
 #include "static_files.h"
-#include "network.h"
 #include "log.h"
 
 #include <stdio.h>
@@ -12,75 +11,6 @@
 
 /* Maximum file size (1MB should be plenty for HTML) */
 #define MAX_FILE_SIZE (1024 * 1024)
-
-/* Banner placeholder in HTML files */
-#define BANNER_PLACEHOLDER "<!-- NETWORK_BANNER -->"
-
-/*
- * Generate banner HTML for a given chain.
- * Returns empty string for mainnet/mixed, banner HTML for test networks.
- */
-static const char *get_banner_html(BitcoinChain chain)
-{
-    switch (chain) {
-        case CHAIN_TESTNET:
-            return "<script>window.__NETWORK__='testnet'</script>"
-                   "<div class=\"network-banner network-banner-testnet\">"
-                   "TESTNET - Coins have no value"
-                   "</div>";
-        case CHAIN_SIGNET:
-            return "<script>window.__NETWORK__='signet'</script>"
-                   "<div class=\"network-banner network-banner-signet\">"
-                   "SIGNET - Coins have no value"
-                   "</div>";
-        case CHAIN_REGTEST:
-            return "<script>window.__NETWORK__='regtest'</script>";
-        case CHAIN_MAINNET:
-        default:
-            return "<script>window.__NETWORK__='mainnet'</script>";
-    }
-}
-
-/*
- * Replace placeholder in content with banner HTML.
- * Returns newly allocated string, caller must free.
- * Returns NULL on error.
- */
-static char *inject_banner(const char *content, size_t content_len,
-                           const char *banner_html, size_t *new_len)
-{
-    size_t banner_len = strlen(banner_html);
-    size_t placeholder_len = strlen(BANNER_PLACEHOLDER);
-
-    /* Find placeholder */
-    char *placeholder_pos = strstr(content, BANNER_PLACEHOLDER);
-    if (!placeholder_pos) {
-        /* No placeholder, return copy of original */
-        char *copy = malloc(content_len + 1);
-        if (!copy) return NULL;
-        memcpy(copy, content, content_len);
-        copy[content_len] = '\0';
-        *new_len = content_len;
-        return copy;
-    }
-
-    /* Calculate new size */
-    size_t new_size = content_len - placeholder_len + banner_len;
-    char *result = malloc(new_size + 1);
-    if (!result) return NULL;
-
-    /* Copy content with banner replacing placeholder */
-    size_t prefix_len = placeholder_pos - content;
-    memcpy(result, content, prefix_len);
-    memcpy(result + prefix_len, banner_html, banner_len);
-    memcpy(result + prefix_len + banner_len,
-           placeholder_pos + placeholder_len,
-           content_len - prefix_len - placeholder_len);
-    result[new_size] = '\0';
-
-    *new_len = new_size;
-    return result;
-}
 
 /*
  * Load a single file into memory.
@@ -161,37 +91,11 @@ static void free_file(StaticFile *file)
     file->length = 0;
 }
 
-/*
- * Inject banner into a loaded static file if needed.
- * For non-mainnet chains, replaces placeholder with banner HTML.
- */
-static int inject_banner_into_file(StaticFile *file, BitcoinChain chain)
-{
-    const char *banner_html = get_banner_html(chain);
-
-    /* No banner needed */
-    if (banner_html[0] == '\0') {
-        return 0;
-    }
-
-    size_t new_len;
-    char *new_content = inject_banner(file->content, file->length,
-                                      banner_html, &new_len);
-    if (!new_content) {
-        return -1;
-    }
-
-    /* Replace content */
-    free(file->content);
-    file->content = new_content;
-    file->length = new_len;
-
-    return 0;
-}
-
 int static_files_load(StaticFiles *files, const char *dir, const Config *config)
 {
     char path[512];
+
+    (void)config; /* No longer used for banner injection */
 
     memset(files, 0, sizeof(StaticFiles));
 
@@ -242,24 +146,6 @@ int static_files_load(StaticFiles *files, const char *dir, const Config *config)
     if (load_file(&files->logos, path, "text/html; charset=utf-8") < 0) {
         static_files_free(files);
         return -1;
-    }
-
-    /* Inject network banner for non-mainnet chains */
-    if (config && network_is_test_network(config->chain)) {
-        log_info("Injecting %s banner into HTML files",
-                 network_chain_to_string(config->chain));
-
-        if (inject_banner_into_file(&files->index, config->chain) < 0 ||
-            inject_banner_into_file(&files->broadcast, config->chain) < 0 ||
-            inject_banner_into_file(&files->result, config->chain) < 0 ||
-            inject_banner_into_file(&files->error, config->chain) < 0 ||
-            inject_banner_into_file(&files->docs, config->chain) < 0 ||
-            inject_banner_into_file(&files->status, config->chain) < 0 ||
-            inject_banner_into_file(&files->logos, config->chain) < 0) {
-            log_error("Failed to inject network banner");
-            static_files_free(files);
-            return -1;
-        }
     }
 
     return 0;

--- a/static/broadcast.html
+++ b/static/broadcast.html
@@ -16,16 +16,16 @@ body{
 }
 a{color:#f7931a;text-decoration:none}
 a:hover{text-decoration:underline}
-code,.mono{font-family:'SF Mono',Consolas,'Liberation Mono',Menlo,monospace}
+code,.mono{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 .container{max-width:1152px;margin:0 auto;padding:0 16px;width:100%}
 @media(min-width:640px){.container{padding:0 24px}}
 
 /* Header */
-.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #1a1a1a}
+.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #333}
 .header-inner{display:flex;align-items:center;justify-content:space-between;height:64px}
 .logo-link{display:flex;align-items:center;gap:8px}
 .logo-link:hover{text-decoration:none}
-.site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',Consolas,monospace}
+.site-name{font-size:18px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 .logo-link:hover .site-name{color:#f7931a}
 nav{display:flex;align-items:center;gap:4px}
 .nav-link{display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;color:#a0a0a0;transition:all .15s}
@@ -67,7 +67,7 @@ nav{display:flex;align-items:center;gap:4px}
 .tx-row{padding:10px 16px;border-bottom:1px solid #2a2a2a;font-size:13px}
 .tx-row:last-child{border-bottom:none}
 .tx-label{color:#888;font-size:12px;margin-bottom:2px}
-.tx-value{color:#fff;font-family:'SF Mono',Consolas,monospace;font-size:13px;word-break:break-all}
+.tx-value{color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;font-size:13px;word-break:break-all}
 .tx-info-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;padding:16px}
 @media(min-width:640px){.tx-info-grid{grid-template-columns:repeat(4,1fr)}}
 .tx-badges{display:flex;flex-wrap:wrap;gap:6px;padding:8px 16px}
@@ -85,13 +85,13 @@ nav{display:flex;align-items:center;gap:4px}
 .result-value{font-size:18px;font-weight:700;color:#fff}
 
 /* Footer */
-.footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+.footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
 .footer-inner{display:flex;flex-direction:column;align-items:center;gap:16px}
 @media(min-width:640px){.footer-inner{flex-direction:row;justify-content:space-between}}
 .footer-links{display:flex;align-items:center;gap:16px}
 .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color .15s}
 .footer-link:hover{color:#fff;text-decoration:none}
-.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a}
+.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #333}
 
 /* Warning */
 .warning-box{background:rgba(234,179,8,.1);border:1px solid rgba(234,179,8,.3);border-radius:8px;padding:12px 16px;display:flex;align-items:flex-start;gap:10px;margin:8px 16px}

--- a/static/broadcast.html
+++ b/static/broadcast.html
@@ -11,7 +11,7 @@ html{scrollbar-gutter:stable}
 :focus-visible{outline:2px solid #f7931a;outline-offset:2px}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:#0f0f0f;color:#e0e0e0;min-height:100vh;display:flex;flex-direction:column;
+  background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
   line-height:1.6;
 }
 a{color:#f7931a;text-decoration:none}
@@ -35,16 +35,16 @@ nav{display:flex;align-items:center;gap:4px}
 @media(min-width:640px){.nav-label{display:inline}}
 
 /* Cards */
-.card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px;box-shadow:0 4px 6px -1px rgb(0 0 0/.3),0 2px 4px -2px rgb(0 0 0/.3)}
+.card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px}
 .card-sm{padding:16px}
 
 /* Badge */
-.badge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:6px;font-size:12px;font-weight:600}
-.badge-success{background:rgba(34,197,94,.15);color:#22c55e;border:1px solid rgba(34,197,94,.3)}
-.badge-error{background:rgba(239,68,68,.15);color:#ef4444;border:1px solid rgba(239,68,68,.3)}
-.badge-warning{background:rgba(234,179,8,.15);color:#eab308;border:1px solid rgba(234,179,8,.3)}
-.badge-info{background:rgba(59,130,246,.15);color:#3b82f6;border:1px solid rgba(59,130,246,.3)}
-.badge-orange{background:rgba(247,147,26,.15);color:#f7931a;border:1px solid rgba(247,147,26,.3)}
+.badge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:6px;font-size:12px;font-weight:500}
+.badge-success{background:rgba(34,197,94,.12);color:#22c55e}
+.badge-error{background:rgba(239,68,68,.12);color:#ef4444}
+.badge-warning{background:rgba(234,179,8,.12);color:#eab308}
+.badge-info{background:rgba(59,130,246,.12);color:#3b82f6}
+.badge-orange{background:rgba(247,147,26,.12);color:#f7931a}
 .badge-muted{background:#1a1a1a;color:#a0a0a0;border:1px solid #333}
 
 /* Status */
@@ -109,8 +109,8 @@ nav{display:flex;align-items:center;gap:4px}
 .error-card{max-width:480px;text-align:center;width:100%}
 
 /* Button */
-.btn{display:inline-flex;align-items:center;gap:8px;padding:10px 20px;border-radius:8px;font-size:14px;font-weight:600;transition:all .15s}
-.btn-primary{background:#f7931a;color:#000}
+.btn{display:inline-flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:16px;font-weight:500;transition:all .15s}
+.btn-primary{background:#f7931a;color:#0f0f0f}
 .btn-primary:hover{background:#ffa940;text-decoration:none}
 .btn-muted{background:#1a1a1a;color:#a0a0a0;border:1px solid #333}
 .btn-muted:hover{color:#fff;background:#252525;text-decoration:none}
@@ -122,8 +122,8 @@ nav{display:flex;align-items:center;gap:4px}
 .ns-limits{display:flex;gap:16px;margin-top:4px;font-size:11px;color:#666}
 
 /* Acceptance bar */
-.acceptance-bar{height:8px;border-radius:4px;background:#333;overflow:hidden;margin:8px 0}
-.acceptance-fill{height:100%;border-radius:4px;background:#22c55e;transition:width .3s}
+.acceptance-bar{height:12px;border-radius:9999px;background:#252525;overflow:hidden;margin:8px 0}
+.acceptance-fill{height:100%;border-radius:9999px;background:#22c55e;transition:width .5s}
 
 /* Endpoint list */
 .endpoint-row{display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid #2a2a2a;font-size:13px}
@@ -133,7 +133,7 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
-::-webkit-scrollbar-thumb:hover{background:#555}
+::-webkit-scrollbar-thumb:hover{background:#666}
 .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
 .network-banner-testnet{background:#7c3aed;color:#fff}
 .network-banner-signet{background:#2563eb;color:#fff}

--- a/static/broadcast.html
+++ b/static/broadcast.html
@@ -134,14 +134,14 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
 ::-webkit-scrollbar-thumb:hover{background:#666}
-.network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-.network-banner-testnet{background:#7c3aed;color:#fff}
-.network-banner-signet{background:#2563eb;color:#fff}
-.network-banner-regtest{background:#059669;color:#fff}
+#network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px;display:none}
+#network-banner.testnet{background:#7c3aed;color:#fff}
+#network-banner.signet{background:#2563eb;color:#fff}
+#network-banner.regtest{background:#059669;color:#fff}
 </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
+<div id="network-banner"></div>
 
 <!-- Header -->
 <header class="header">
@@ -188,9 +188,6 @@ nav{display:flex;align-items:center;gap:4px}
       <a href="/" style="display:inline-flex;align-items:center;gap:8px;color:#f7931a;font-size:14px">Back to Broadcast</a>
     </div>
   </div>
-
-  <!-- Dynamic Network Detection Banner -->
-  <div id="chain-detect-banner" style="display:none;margin-bottom:16px;padding:10px 16px;border-radius:8px;font-size:13px;font-weight:500;text-align:center"></div>
 
   <!-- Transaction Preview -->
   <div id="txPreviewSection" style="display:none;margin-bottom:32px">
@@ -623,8 +620,12 @@ function parseOpReturnData(data) {
   };
 }
 
+function getSelectedNetwork() {
+  return localStorage.getItem('sendrawtx-network') || 'mainnet';
+}
+
 async function scriptToAddress(scriptType, data, isMainnet) {
-  var net = window.__NETWORK__ || 'mainnet';
+  var net = getSelectedNetwork();
   if (isMainnet === undefined) isMainnet = (net === 'mainnet');
   var hrp = net === 'regtest' ? 'bcrt' : (isMainnet ? 'bc' : 'tb');
 
@@ -2817,43 +2818,27 @@ var attempt = 0;
 var maxAttempts = 15;
 var baseDelay = 500;
 
-function detectChainFromAddress(addr) {
-  if (!addr) return null;
-  if (addr.startsWith('bcrt1')) return 'regtest';
-  if (addr.startsWith('tb1')) return 'testnet';
-  if (addr.startsWith('bc1')) return 'mainnet';
-  if ('mn2'.includes(addr[0])) return 'testnet';
-  if ('13'.includes(addr[0])) return 'mainnet';
-  return null;
-}
-
-var chainBannerColors = {
-  regtest: { bg: 'rgba(5,150,105,0.15)', border: 'rgba(5,150,105,0.4)', color: '#34d399' },
-  testnet: { bg: 'rgba(124,58,237,0.15)', border: 'rgba(124,58,237,0.4)', color: '#a78bfa' },
-  signet:  { bg: 'rgba(37,99,235,0.15)', border: 'rgba(37,99,235,0.4)', color: '#60a5fa' },
-  mainnet: { bg: 'rgba(247,147,26,0.15)', border: 'rgba(247,147,26,0.4)', color: '#f7931a' }
+var networkLabels = {
+  testnet: 'TESTNET \u2014 Coins have no value',
+  signet: 'SIGNET \u2014 Coins have no value',
+  regtest: 'REGTEST \u2014 Local test network'
 };
 
-function updateChainDetectBanner(outputs) {
-  var banner = document.getElementById('chain-detect-banner');
-  if (!banner || !outputs || outputs.length === 0) { if (banner) banner.style.display = 'none'; return; }
-  var detected = null;
-  var sample = '';
-  for (var i = 0; i < outputs.length; i++) {
-    var addr = outputs[i].address;
-    if (!addr) continue;
-    var chain = detectChainFromAddress(addr);
-    if (chain) { detected = chain; sample = addr.length > 12 ? addr.slice(0, 12) + '...' : addr; break; }
+function updateNetworkBanner() {
+  var net = getSelectedNetwork();
+  var banner = document.getElementById('network-banner');
+  banner.className = '';
+  if (net !== 'mainnet' && networkLabels[net]) {
+    banner.className = net;
+    banner.textContent = networkLabels[net];
+    banner.style.display = 'block';
+  } else {
+    banner.style.display = 'none';
   }
-  if (!detected || detected === 'mainnet') { banner.style.display = 'none'; return; }
-  var c = chainBannerColors[detected] || chainBannerColors.testnet;
-  var label = detected.toUpperCase();
-  banner.style.display = 'block';
-  banner.style.background = c.bg;
-  banner.style.border = '1px solid ' + c.border;
-  banner.style.color = c.color;
-  banner.textContent = 'This transaction targets ' + label + ' \u2014 outputs contain ' + sample + ' addresses';
 }
+
+/* Show banner on load based on localStorage */
+updateNetworkBanner();
 
 init();
 
@@ -2871,7 +2856,6 @@ async function init() {
     }
     renderPreview(result);
     var outputs = result.type === 'psbt' ? (result.data.unsignedTx && result.data.unsignedTx.outputs || []) : (result.data.outputs || []);
-    updateChainDetectBanner(outputs);
     if (txid) setTimeout(poll, baseDelay);
   } catch (err) {
     console.error('Decode error:', err);

--- a/static/docs.html
+++ b/static/docs.html
@@ -95,15 +95,10 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
 ::-webkit-scrollbar-thumb:hover{background:#666}
-.network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-.network-banner-testnet{background:#7c3aed;color:#fff}
-.network-banner-signet{background:#2563eb;color:#fff}
-.network-banner-regtest{background:#059669;color:#fff}
+
 </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
-
 <!-- Header -->
 <header class="header">
 <div class="header-inner">

--- a/static/docs.html
+++ b/static/docs.html
@@ -12,7 +12,7 @@ html{scrollbar-gutter:stable}
 :focus-visible{outline:2px solid #f7931a;outline-offset:2px}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:#0f0f0f;color:#e0e0e0;min-height:100vh;display:flex;flex-direction:column;
+  background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
   line-height:1.6;
 }
 a{color:#f7931a;text-decoration:none}
@@ -39,7 +39,7 @@ nav{display:flex;align-items:center;gap:4px}
 @media(min-width:640px){.page-container{padding:0 24px}}
 
 /* Cards — matches React Card variant="bordered" */
-.card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px;margin-bottom:32px;box-shadow:0 4px 6px -1px rgb(0 0 0/.3),0 2px 4px -2px rgb(0 0 0/.3)}
+.card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px;margin-bottom:32px}
 .card-header{margin-bottom:16px}
 .card-title{font-size:18px;font-weight:600;color:#fff;display:flex;align-items:center;gap:8px}
 .card-content{color:#a0a0a0}
@@ -94,7 +94,7 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
-::-webkit-scrollbar-thumb:hover{background:#555}
+::-webkit-scrollbar-thumb:hover{background:#666}
 .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
 .network-banner-testnet{background:#7c3aed;color:#fff}
 .network-banner-signet{background:#2563eb;color:#fff}

--- a/static/docs.html
+++ b/static/docs.html
@@ -17,15 +17,15 @@ body{
 }
 a{color:#f7931a;text-decoration:none}
 a:hover{text-decoration:underline}
-code,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace}
+code,.mono{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 
 /* Header */
-.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #1a1a1a}
+.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #333}
 .header-inner{max-width:1152px;margin:0 auto;padding:0 16px;display:flex;align-items:center;justify-content:space-between;height:64px}
 @media(min-width:640px){.header-inner{padding:0 24px}}
 .logo-link{display:flex;align-items:center;gap:8px}
 .logo-link:hover{text-decoration:none}
-.site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;transition:color .15s}
+.site-name{font-size:18px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;transition:color .15s}
 .logo-link:hover .site-name{color:#f7931a}
 nav{display:flex;align-items:center;gap:4px}
 .nav-link{display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;color:#a0a0a0;transition:all .15s}
@@ -52,7 +52,7 @@ nav{display:flex;align-items:center;gap:4px}
 .badge-success{background:rgba(34,197,94,.12);color:#22c55e}
 
 /* Code blocks */
-.code-block{background:#0f0f0f;border-radius:8px;padding:16px;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;font-size:14px;overflow-x:auto}
+.code-block{background:#0f0f0f;border-radius:8px;padding:16px;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;font-size:14px;overflow-x:auto}
 .code-block pre{margin:0;color:#a0a0a0;white-space:pre;line-height:1.6}
 .code-green{color:#22c55e}
 .code-white{color:#fff}
@@ -63,11 +63,11 @@ nav{display:flex;align-items:center;gap:4px}
 .endpoint-card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px}
 .endpoint-header{margin-bottom:16px}
 .endpoint-title{font-size:18px;font-weight:600;color:#fff;display:flex;align-items:center;gap:8px}
-.endpoint-path{font-family:'SF Mono',SFMono-Regular,Consolas,monospace;color:#fff}
+.endpoint-path{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;color:#fff}
 .endpoint-desc{color:#a0a0a0;margin-bottom:16px}
 .endpoint-note{font-size:14px;color:#666;margin-bottom:16px}
 .endpoint-example-label{font-size:14px;color:#666;margin-bottom:8px}
-.endpoint-example{background:#0f0f0f;border-radius:8px;padding:12px;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;font-size:14px;overflow-x:auto}
+.endpoint-example{background:#0f0f0f;border-radius:8px;padding:12px;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;font-size:14px;overflow-x:auto}
 .endpoint-example code{color:#a0a0a0}
 .endpoints-list{display:flex;flex-direction:column;gap:24px;margin-bottom:32px}
 
@@ -82,7 +82,7 @@ nav{display:flex;align-items:center;gap:4px}
 .section-heading{font-size:20px;font-weight:600;color:#fff;margin-bottom:24px}
 
 /* Footer */
-.footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+.footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
 .footer-container{max-width:1152px;margin:0 auto;padding:0 16px}
 @media(min-width:640px){.footer-container{padding:0 24px}}
 .footer-inner{display:flex;flex-direction:column;align-items:center;gap:16px}
@@ -90,7 +90,7 @@ nav{display:flex;align-items:center;gap:4px}
 .footer-links{display:flex;align-items:center;gap:16px}
 .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color .15s}
 .footer-link:hover{color:#fff;text-decoration:none}
-.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a}
+.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #333}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}

--- a/static/error.html
+++ b/static/error.html
@@ -58,15 +58,10 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
 ::-webkit-scrollbar-thumb:hover{background:#666}
-.network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-.network-banner-testnet{background:#7c3aed;color:#fff}
-.network-banner-signet{background:#2563eb;color:#fff}
-.network-banner-regtest{background:#059669;color:#fff}
+
 </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
-
 <!-- Header -->
 <header class="header">
 <div class="header-inner">

--- a/static/error.html
+++ b/static/error.html
@@ -16,15 +16,15 @@ body{
 }
 a{color:#f7931a;text-decoration:none}
 a:hover{text-decoration:underline}
-code,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace}
+code,.mono{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 
 /* Header */
-.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #1a1a1a}
+.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #333}
 .header-inner{max-width:1152px;margin:0 auto;padding:0 16px;display:flex;align-items:center;justify-content:space-between;height:64px}
 @media(min-width:640px){.header-inner{padding:0 24px}}
 .logo-link{display:flex;align-items:center;gap:8px}
 .logo-link:hover{text-decoration:none}
-.site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;transition:color .15s}
+.site-name{font-size:18px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;transition:color .15s}
 .logo-link:hover .site-name{color:#f7931a}
 nav{display:flex;align-items:center;gap:4px}
 .nav-link{display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;color:#a0a0a0;transition:all .15s}
@@ -45,7 +45,7 @@ nav{display:flex;align-items:center;gap:4px}
 .btn-primary:hover{background:#ffa940;text-decoration:none}
 
 /* Footer */
-.footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+.footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
 .footer-container{max-width:1152px;margin:0 auto;padding:0 16px}
 @media(min-width:640px){.footer-container{padding:0 24px}}
 .footer-inner{display:flex;flex-direction:column;align-items:center;gap:16px}
@@ -53,7 +53,7 @@ nav{display:flex;align-items:center;gap:4px}
 .footer-links{display:flex;align-items:center;gap:16px}
 .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color .15s}
 .footer-link:hover{color:#fff;text-decoration:none}
-.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a}
+.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #333}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}

--- a/static/error.html
+++ b/static/error.html
@@ -11,7 +11,7 @@ html{scrollbar-gutter:stable}
 :focus-visible{outline:2px solid #f7931a;outline-offset:2px}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:#0f0f0f;color:#e0e0e0;min-height:100vh;display:flex;flex-direction:column;
+  background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
   line-height:1.6;
 }
 a{color:#f7931a;text-decoration:none}
@@ -35,7 +35,7 @@ nav{display:flex;align-items:center;gap:4px}
 
 /* Error content — matches React centered Card layout */
 .error-center{display:flex;align-items:center;justify-content:center;flex:1;padding:48px 16px}
-.error-card{background:#1a1a1a;border-radius:12px;padding:24px;max-width:448px;width:100%;text-align:center;box-shadow:0 4px 6px -1px rgb(0 0 0/.3),0 2px 4px -2px rgb(0 0 0/.3)}
+.error-card{background:#1a1a1a;border-radius:12px;padding:24px;max-width:448px;width:100%;text-align:center}
 .error-icon{margin:0 auto 16px}
 .error-title{font-size:30px;font-weight:700;color:#fff;margin-bottom:8px}
 .error-subtitle{color:#a0a0a0;margin-bottom:24px}
@@ -57,7 +57,7 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
-::-webkit-scrollbar-thumb:hover{background:#555}
+::-webkit-scrollbar-thumb:hover{background:#666}
 .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
 .network-banner-testnet{background:#7c3aed;color:#fff}
 .network-banner-signet{background:#2563eb;color:#fff}

--- a/static/index.html
+++ b/static/index.html
@@ -12,7 +12,7 @@ html{scroll-behavior:smooth;scrollbar-gutter:stable}
 :focus-visible{outline:2px solid #f7931a;outline-offset:2px}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:#0f0f0f;color:#e0e0e0;min-height:100vh;display:flex;flex-direction:column;
+  background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
   line-height:1.6;-webkit-font-smoothing:antialiased;
 }
 a{color:inherit;text-decoration:none}
@@ -77,19 +77,19 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 .bg-orange{background:#f7931a}
 
 /* Card */
-.card{background:#1a1a1a;border-radius:12px;box-shadow:0 4px 6px -1px rgb(0 0 0/.3),0 2px 4px -2px rgb(0 0 0/.3)}
-.card-bordered{background:#1a1a1a;border:1px solid #333;border-radius:12px;box-shadow:0 4px 6px -1px rgb(0 0 0/.3),0 2px 4px -2px rgb(0 0 0/.3)}
+.card{background:#1a1a1a;border-radius:12px}
+.card-bordered{background:#1a1a1a;border:1px solid #333;border-radius:12px}
 .card-header{padding:16px 16px 0}
-.card-title{font-size:16px;font-weight:600;color:#fff;display:flex;align-items:center;gap:8px}
+.card-title{font-size:18px;font-weight:600;color:#fff;display:flex;align-items:center;gap:8px}
 .card-content{padding:24px}
 
 /* Badge */
-.badge{display:inline-flex;align-items:center;padding:2px 8px;border-radius:9999px;font-size:12px;font-weight:500}
-.badge-info{background:rgba(59,130,246,0.2);color:#3b82f6}
-.badge-success{background:rgba(34,197,94,0.2);color:#22c55e}
-.badge-warning{background:rgba(234,179,8,0.2);color:#eab308}
-.badge-error{background:rgba(239,68,68,0.2);color:#ef4444}
-.badge-sm{font-size:11px;padding:1px 6px}
+.badge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:6px;font-size:12px;font-weight:500}
+.badge-info{background:rgba(59,130,246,0.12);color:#3b82f6}
+.badge-success{background:rgba(34,197,94,0.12);color:#22c55e}
+.badge-warning{background:rgba(234,179,8,0.12);color:#eab308}
+.badge-error{background:rgba(239,68,68,0.12);color:#ef4444}
+.badge-sm{font-size:12px;padding:2px 8px}
 
 /* Header */
 #site-header{
@@ -121,22 +121,22 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 /* Buttons */
 .btn{
   display:inline-flex;align-items:center;justify-content:center;gap:8px;
-  padding:10px 20px;border-radius:8px;font-size:14px;font-weight:600;
-  transition:all 0.2s;cursor:pointer;border:none;
+  padding:8px 16px;border-radius:8px;font-size:16px;font-weight:500;
+  transition:all .15s;cursor:pointer;border:none;
 }
 .btn-primary{background:#f7931a;color:#0f0f0f}
-.btn-primary:hover{background:#ffa940}
+.btn-primary:hover{background:#ffa940;text-decoration:none}
 .btn-primary:disabled{opacity:0.5;cursor:not-allowed}
-.btn-secondary{background:#252525;color:#a0a0a0;border:1px solid #333}
-.btn-secondary:hover{color:#fff;border-color:#555}
+.btn-secondary{background:#252525;color:#fff;border:1px solid #333}
+.btn-secondary:hover{color:#fff;background:#2d2d2d;border-color:#444}
 .btn-secondary:disabled{opacity:0.5;cursor:not-allowed}
-.btn-lg{padding:12px 24px;font-size:16px}
+.btn-lg{padding:12px 24px;font-size:18px}
 
 /* Textarea */
 .tx-textarea{
-  width:100%;padding:12px;border-radius:8px;border:1px solid #333;
-  background:#252525;color:#e0e0e0;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;
-  font-size:13px;resize:vertical;outline:none;transition:border-color 0.2s,box-shadow 0.2s;
+  width:100%;padding:12px 16px;border-radius:8px;border:1px solid #333;
+  background:#252525;color:#fff;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;
+  font-size:14px;resize:none;outline:none;transition:border-color .15s,box-shadow .15s;
 }
 .tx-textarea:focus{border-color:#f7931a;box-shadow:0 0 0 1px #f7931a}
 .tx-textarea::placeholder{color:#666}
@@ -195,7 +195,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 @media(min-width:768px){.tx-info-grid{grid-template-columns:repeat(4,1fr)}}
 .tx-info-box{background:#1a1a1a;border-radius:8px;padding:12px}
 .tx-info-label{font-size:12px;color:#666;margin-bottom:4px;display:flex;align-items:center;gap:4px}
-.tx-info-value{font-size:14px;font-weight:500;color:#e0e0e0}
+.tx-info-value{font-size:14px;font-weight:500;color:#fff}
 .tx-badge{
   display:inline-flex;align-items:center;gap:4px;
   font-size:12px;padding:4px 8px;border-radius:4px;
@@ -206,14 +206,14 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 .expand-detail{margin-top:12px;padding-top:12px;border-top:1px solid #333}
 .detail-row{display:flex;justify-content:space-between;font-size:12px;margin-bottom:8px}
 .detail-label{color:#666}.detail-value{color:#a0a0a0}
-.copy-btn{color:#666;transition:color 0.2s;background:none;border:none;cursor:pointer;padding:2px}
-.copy-btn:hover{color:#a0a0a0}
+.copy-btn{display:inline-flex;align-items:center;gap:4px;padding:4px 8px;border-radius:4px;font-size:12px;color:#a0a0a0;background:transparent;border:1px solid transparent;cursor:pointer;transition:all .15s}
+.copy-btn:hover{color:#fff;background:#333;border-color:#444}
 
 /* Scrollbar */
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
-::-webkit-scrollbar-thumb:hover{background:#555}
+::-webkit-scrollbar-thumb:hover{background:#666}
 .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
 .network-banner-testnet{background:#7c3aed;color:#fff}
 .network-banner-signet{background:#2563eb;color:#fff}

--- a/static/index.html
+++ b/static/index.html
@@ -214,14 +214,16 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
 ::-webkit-scrollbar-thumb:hover{background:#666}
-.network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-.network-banner-testnet{background:#7c3aed;color:#fff}
-.network-banner-signet{background:#2563eb;color:#fff}
-.network-banner-regtest{background:#059669;color:#fff}
+#network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px;display:none}
+#network-banner.testnet{background:#7c3aed;color:#fff}
+#network-banner.signet{background:#2563eb;color:#fff}
+#network-banner.regtest{background:#059669;color:#fff}
+.net-select{background:#1a1a1a;color:#a0a0a0;border:1px solid #333;border-radius:6px;padding:4px 8px;font-size:12px;font-family:inherit;cursor:pointer;outline:none}
+.net-select:focus{border-color:#f7931a}
 </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
+<div id="network-banner"></div>
 
 <!-- HEADER -->
 <header id="site-header">
@@ -270,16 +272,24 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
       <!-- Broadcast Form Card -->
       <div class="card-bordered max-w-2xl mx-auto text-left">
         <div class="card-content">
-          <!-- Mode Toggle -->
-          <div class="mode-toggle">
-            <button class="mode-btn active-preview" id="btn-preview" onclick="setMode('preview')">
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-              Preview Only
-            </button>
-            <button class="mode-btn" id="btn-broadcast" onclick="setMode('broadcast')">
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 010 8.49m-8.48-.01a6 6 0 010-8.49m11.31-2.82a10 10 0 010 14.14m-14.14 0a10 10 0 010-14.14"/></svg>
-              Broadcast
-            </button>
+          <!-- Mode Toggle + Network Selector -->
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0">
+            <div class="mode-toggle" style="margin-bottom:0">
+              <button class="mode-btn active-preview" id="btn-preview" onclick="setMode('preview')">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                Preview Only
+              </button>
+              <button class="mode-btn" id="btn-broadcast" onclick="setMode('broadcast')">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 010 8.49m-8.48-.01a6 6 0 010-8.49m11.31-2.82a10 10 0 010 14.14m-14.14 0a10 10 0 010-14.14"/></svg>
+                Broadcast
+              </button>
+            </div>
+            <select id="net-select" class="net-select" onchange="onNetworkChange()">
+              <option value="mainnet">Mainnet</option>
+              <option value="testnet">Testnet</option>
+              <option value="signet">Signet</option>
+              <option value="regtest">Regtest</option>
+            </select>
           </div>
 
           <textarea id="tx-input" class="tx-textarea" rows="6"
@@ -299,9 +309,6 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
           </div>
         </div>
       </div>
-
-      <!-- Dynamic Network Detection Banner -->
-      <div id="chain-detect-banner" class="max-w-2xl mx-auto" style="display:none;margin-top:16px;padding:10px 16px;border-radius:8px;font-size:13px;font-weight:500;text-align:center"></div>
 
       <!-- Transaction Preview Container -->
       <div id="tx-preview-container" class="max-w-2xl mx-auto" style="margin-top:24px;display:none"></div>
@@ -756,8 +763,12 @@ function parseOpReturnData(data) {
   };
 }
 
+function getSelectedNetwork() {
+  return localStorage.getItem('sendrawtx-network') || 'mainnet';
+}
+
 async function scriptToAddress(scriptType, data, isMainnet) {
-  var net = window.__NETWORK__ || 'mainnet';
+  var net = getSelectedNetwork();
   if (isMainnet === undefined) isMainnet = (net === 'mainnet');
   var hrp = net === 'regtest' ? 'bcrt' : (isMainnet ? 'bc' : 'tb');
 
@@ -3012,7 +3023,7 @@ function handleTxInput() {
   if (!val.trim()) {
     document.getElementById('tx-preview-container').style.display = 'none';
     document.getElementById('tx-preview-container').innerHTML = '';
-    document.getElementById('chain-detect-banner').style.display = 'none';
+
     txValid = false;
     txCanBroadcast = false;
     updateStatusBar();
@@ -3077,45 +3088,43 @@ function handleBroadcast() {
 }
 
 /* ============================================================
-   NETWORK DETECTION
+   NETWORK SELECTOR + TOP BANNER
    ============================================================ */
-function detectChainFromAddress(addr) {
-  if (!addr) return null;
-  if (addr.startsWith('bcrt1')) return 'regtest';
-  if (addr.startsWith('tb1')) return 'testnet';
-  if (addr.startsWith('bc1')) return 'mainnet';
-  if ('mn2'.includes(addr[0])) return 'testnet';
-  if ('13'.includes(addr[0])) return 'mainnet';
-  return null;
-}
-
-var chainBannerColors = {
-  regtest: { bg: 'rgba(5,150,105,0.15)', border: 'rgba(5,150,105,0.4)', color: '#34d399' },
-  testnet: { bg: 'rgba(124,58,237,0.15)', border: 'rgba(124,58,237,0.4)', color: '#a78bfa' },
-  signet:  { bg: 'rgba(37,99,235,0.15)', border: 'rgba(37,99,235,0.4)', color: '#60a5fa' },
-  mainnet: { bg: 'rgba(247,147,26,0.15)', border: 'rgba(247,147,26,0.4)', color: '#f7931a' }
+var networkLabels = {
+  testnet: 'TESTNET \u2014 Coins have no value',
+  signet: 'SIGNET \u2014 Coins have no value',
+  regtest: 'REGTEST \u2014 Local test network'
 };
 
-function updateChainDetectBanner(outputs) {
-  var banner = document.getElementById('chain-detect-banner');
-  if (!banner || !outputs || outputs.length === 0) { if (banner) banner.style.display = 'none'; return; }
-  var detected = null;
-  var sample = '';
-  for (var i = 0; i < outputs.length; i++) {
-    var addr = outputs[i].address;
-    if (!addr) continue;
-    var chain = detectChainFromAddress(addr);
-    if (chain) { detected = chain; sample = addr.length > 12 ? addr.slice(0, 12) + '...' : addr; break; }
+function updateNetworkBanner() {
+  var net = getSelectedNetwork();
+  var banner = document.getElementById('network-banner');
+  banner.className = '';
+  if (net !== 'mainnet' && networkLabels[net]) {
+    banner.className = net;
+    banner.textContent = networkLabels[net];
+    banner.style.display = 'block';
+  } else {
+    banner.style.display = 'none';
   }
-  if (!detected || detected === 'mainnet') { banner.style.display = 'none'; return; }
-  var c = chainBannerColors[detected] || chainBannerColors.testnet;
-  var label = detected.toUpperCase();
-  banner.style.display = 'block';
-  banner.style.background = c.bg;
-  banner.style.border = '1px solid ' + c.border;
-  banner.style.color = c.color;
-  banner.textContent = 'This transaction targets ' + label + ' \u2014 outputs contain ' + sample + ' addresses';
 }
+
+function onNetworkChange() {
+  var sel = document.getElementById('net-select').value;
+  localStorage.setItem('sendrawtx-network', sel);
+  updateNetworkBanner();
+  /* Re-decode current TX with new network encoding */
+  var val = document.getElementById('tx-input').value.trim();
+  if (val) decodeTxPreview(val);
+}
+
+/* Initialize network selector from localStorage */
+(function() {
+  var saved = getSelectedNetwork();
+  var sel = document.getElementById('net-select');
+  if (sel) sel.value = saved;
+  updateNetworkBanner();
+})();
 
 /* ============================================================
    TRANSACTION PREVIEW
@@ -3125,7 +3134,7 @@ function decodeTxPreview(rawTx) {
   if (!rawTx.trim()) {
     container.style.display = 'none';
     container.innerHTML = '';
-    document.getElementById('chain-detect-banner').style.display = 'none';
+
     return;
   }
 
@@ -3158,12 +3167,12 @@ function decodeTxPreview(rawTx) {
     updateStatusBar();
     renderDecodeResult(container, result);
     var outputs = result.type === 'psbt' ? (result.data.unsignedTx && result.data.unsignedTx.outputs || []) : (result.data.outputs || []);
-    updateChainDetectBanner(outputs);
+    /* Network banner is controlled by selector, not per-TX detection */
   }).catch(function(err) {
     txValid = false;
     txCanBroadcast = false;
     updateStatusBar();
-    document.getElementById('chain-detect-banner').style.display = 'none';
+
     container.innerHTML = '<div style="background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:8px;padding:16px"><div class="flex items-start gap-2">' + icon('AlertTriangle', 16, '#ef4444') + ' <span class="text-sm text-red">' + escapeHtml(err.message || 'Failed to decode transaction') + '</span></div></div>';
   });
 }

--- a/static/index.html
+++ b/static/index.html
@@ -13,11 +13,11 @@ html{scroll-behavior:smooth;scrollbar-gutter:stable}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
-  line-height:1.6;-webkit-font-smoothing:antialiased;
+  line-height:1.5;-webkit-font-smoothing:antialiased;
 }
 a{color:inherit;text-decoration:none}
 button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
-code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace}
+code,pre,.mono{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 .hidden{display:none!important}
 
 /* Layout */
@@ -35,7 +35,8 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 .mb-1{margin-bottom:4px}.mb-2{margin-bottom:8px}.mb-3{margin-bottom:12px}.mb-4{margin-bottom:16px}.mb-6{margin-bottom:24px}.mb-8{margin-bottom:32px}
 .pt-1{padding-top:4px}.pt-3{padding-top:12px}.pt-4{padding-top:16px}
 .p-1{padding:4px}.p-2{padding:8px}.p-3{padding:12px}.p-4{padding:16px}
-.px-2{padding-left:8px;padding-right:8px}.px-4{padding-left:16px;padding-right:16px}
+.px-2{padding-left:8px;padding-right:8px}.px-4{padding-left:16px;padding-right:16px}.px-section{padding-left:16px;padding-right:16px}
+@media(min-width:640px){.px-section{padding-left:24px;padding-right:24px}}
 .py-1{padding-top:4px;padding-bottom:4px}.py-2{padding-top:8px;padding-bottom:8px}
 .py-8{padding-top:32px;padding-bottom:32px}.py-12{padding-top:48px;padding-bottom:48px}
 .truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -95,16 +96,16 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 #site-header{
   position:sticky;top:0;z-index:50;
   background:rgba(15,15,15,0.95);backdrop-filter:blur(8px);
-  border-bottom:1px solid #1a1a1a;
+  border-bottom:1px solid #333;
 }
 #site-header .inner{display:flex;align-items:center;justify-content:space-between;height:64px}
 #site-header .logo-link{display:flex;align-items:center;gap:8px;transition:color 0.2s}
 #site-header .logo-link:hover .site-name{color:#f7931a}
-.site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;transition:color 0.2s}
+.site-name{font-size:18px;line-height:28px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;transition:color 0.2s}
 #site-header nav{display:flex;align-items:center;gap:4px}
 .nav-link{
   display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;
-  font-size:14px;font-weight:500;color:#a0a0a0;transition:all 0.2s;
+  font-size:14px;line-height:20px;font-weight:500;color:#a0a0a0;transition:all 0.2s;
 }
 .nav-link:hover{color:#fff;background:#1a1a1a}
 .nav-link.active{color:#fff;background:#1a1a1a}
@@ -112,7 +113,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 @media(min-width:640px){.nav-link .nav-label{display:inline}}
 
 /* Footer */
-#site-footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+#site-footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
 #site-footer .footer-inner-wrap{display:flex;flex-direction:column;align-items:center;gap:16px}
 @media(min-width:640px){#site-footer .footer-inner-wrap{flex-direction:row;justify-content:space-between}}
 .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color 0.2s}
@@ -130,13 +131,14 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 .btn-secondary{background:#252525;color:#fff;border:1px solid #333}
 .btn-secondary:hover{color:#fff;background:#2d2d2d;border-color:#444}
 .btn-secondary:disabled{opacity:0.5;cursor:not-allowed}
-.btn-lg{padding:12px 24px;font-size:18px}
+.btn-lg{padding:12px 24px;font-size:18px;line-height:28px}
 
 /* Textarea */
 .tx-textarea{
   width:100%;padding:12px 16px;border-radius:8px;border:1px solid #333;
-  background:#252525;color:#fff;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;
-  font-size:14px;resize:none;outline:none;transition:border-color .15s,box-shadow .15s;
+  background:#252525;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;
+  font-size:14px;line-height:20px;resize:none;outline:none;transition:border-color .15s,box-shadow .15s;
+  margin-bottom:16px;
 }
 .tx-textarea:focus{border-color:#f7931a;box-shadow:0 0 0 1px #f7931a}
 .tx-textarea::placeholder{color:#666}
@@ -149,7 +151,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 }
 .mode-btn{
   display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:6px;
-  font-size:14px;font-weight:500;color:#666;transition:all 0.2s;
+  font-size:14px;line-height:20px;font-weight:500;color:#666;transition:all 0.2s;
 }
 .mode-btn:hover{color:#a0a0a0}
 .mode-btn.active-preview{background:#252525;color:#fff}
@@ -185,7 +187,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 .animate-spin{animation:spin 1s linear infinite}
 
 /* Border */
-.border-t{border-top:1px solid #1a1a1a}
+.border-t{border-top:1px solid #333}
 .border-b{border-bottom:1px solid #333}
 .border{border:1px solid #333}
 
@@ -263,7 +265,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 
 <!-- ==================== HOME ==================== -->
   <section class="py-12 sm-py-20">
-    <div class="max-w-4xl mx-auto text-center" style="padding:0 16px">
+    <div class="max-w-4xl mx-auto text-center px-section">
       <h1 class="text-4xl sm-text-5xl font-bold text-white mb-4">Broadcast Raw Transactions</h1>
       <p class="text-lg sm-text-xl text-muted mb-8 max-w-2xl mx-auto">
         The non-standard TX specialist. Route transactions through permissive nodes when standard services reject them.
@@ -272,24 +274,16 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
       <!-- Broadcast Form Card -->
       <div class="card-bordered max-w-2xl mx-auto text-left">
         <div class="card-content">
-          <!-- Mode Toggle + Network Selector -->
-          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0">
-            <div class="mode-toggle" style="margin-bottom:0">
-              <button class="mode-btn active-preview" id="btn-preview" onclick="setMode('preview')">
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                Preview Only
-              </button>
-              <button class="mode-btn" id="btn-broadcast" onclick="setMode('broadcast')">
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 010 8.49m-8.48-.01a6 6 0 010-8.49m11.31-2.82a10 10 0 010 14.14m-14.14 0a10 10 0 010-14.14"/></svg>
-                Broadcast
-              </button>
-            </div>
-            <select id="net-select" class="net-select" onchange="onNetworkChange()">
-              <option value="mainnet">Mainnet</option>
-              <option value="testnet">Testnet</option>
-              <option value="signet">Signet</option>
-              <option value="regtest">Regtest</option>
-            </select>
+          <!-- Mode Toggle -->
+          <div class="mode-toggle">
+            <button class="mode-btn" id="btn-preview" onclick="setMode('preview')">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+              Preview Only
+            </button>
+            <button class="mode-btn active-broadcast" id="btn-broadcast" onclick="setMode('broadcast')">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 010 8.49m-8.48-.01a6 6 0 010-8.49m11.31-2.82a10 10 0 010 14.14m-14.14 0a10 10 0 010-14.14"/></svg>
+              Broadcast
+            </button>
           </div>
 
           <textarea id="tx-input" class="tx-textarea" rows="6"
@@ -304,8 +298,16 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
           </div>
 
           <div class="flex items-center justify-between" style="margin-top:16px">
-            <span class="text-sm text-secondary" id="tx-status-left"></span>
-            <span id="tx-status-right"></span>
+            <div style="display:flex;align-items:center;gap:8px">
+              <select id="net-select" class="net-select" onchange="onNetworkChange()">
+                <option value="mainnet">Mainnet</option>
+                <option value="testnet">Testnet</option>
+                <option value="signet">Signet</option>
+                <option value="regtest">Regtest</option>
+              </select>
+              <span class="text-sm text-secondary" id="tx-status-left"></span>
+            </div>
+            <span id="tx-status-right"><button class="btn btn-primary btn-lg" disabled><span>Broadcast</span> <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></button></span>
           </div>
         </div>
       </div>
@@ -317,7 +319,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 
   <!-- Features -->
   <section class="py-12 border-t">
-    <div class="max-w-6xl mx-auto" style="padding:0 16px">
+    <div class="max-w-6xl mx-auto px-section">
       <div class="grid sm-grid-cols-3" style="gap:24px">
         <div class="card text-center"><div class="card-content">
           <div class="feature-icon"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#f7931a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></div>
@@ -340,7 +342,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
 
   <!-- How It Works -->
   <section class="py-12 border-t">
-    <div class="max-w-4xl mx-auto" style="padding:0 16px">
+    <div class="max-w-4xl mx-auto px-section">
       <h2 class="text-2xl font-bold text-white text-center mb-8">How It Works</h2>
       <div style="display:flex;flex-direction:column;gap:16px">
         <div class="flex items-start gap-4"><div class="step-circle">1</div><div class="pt-1 flex-1"><p class="text-muted">Paste your raw transaction hex</p></div></div>
@@ -372,7 +374,7 @@ code,pre,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',M
         </a>
       </div>
     </div>
-    <div style="margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a;text-align:center">
+    <div style="margin-top:24px;padding-top:24px;border-top:1px solid #333;text-align:center">
       <p style="font-size:12px;color:#666">Built with Bitcoin Core, Knots, and Libre Relay</p>
     </div>
 
@@ -3048,7 +3050,7 @@ function updateStatusBar() {
   if (val.length === 0) {
     leftEl.innerHTML = '';
     if (broadcastMode === 'broadcast') {
-      rightEl.innerHTML = '<button class="btn btn-primary" disabled><span>Broadcast</span> ' + icon('ArrowRight', 20, '#666') + '</button>';
+      rightEl.innerHTML = '<button class="btn btn-primary btn-lg" disabled><span>Broadcast</span> ' + icon('ArrowRight', 20, '#666') + '</button>';
     } else {
       rightEl.innerHTML = '';
     }
@@ -3064,7 +3066,7 @@ function updateStatusBar() {
 
   if (broadcastMode === 'broadcast') {
     var disabled = !val || !txCanBroadcast;
-    rightEl.innerHTML = '<button class="btn btn-primary' + (disabled ? '' : '') + '" onclick="handleBroadcast()"' + (disabled ? ' disabled' : '') + '><span>Broadcast</span> ' + icon('ArrowRight', 20, disabled ? '#666' : '#0f0f0f') + '</button>';
+    rightEl.innerHTML = '<button class="btn btn-primary btn-lg" onclick="handleBroadcast()"' + (disabled ? ' disabled' : '') + '><span>Broadcast</span> ' + icon('ArrowRight', 20, disabled ? '#666' : '#0f0f0f') + '</button>';
   } else {
     rightEl.innerHTML = '<span class="text-sm text-secondary italic">Preview mode - decoding only</span>';
   }

--- a/static/logos.html
+++ b/static/logos.html
@@ -16,16 +16,16 @@ body{
 }
 a{color:#f7931a;text-decoration:none}
 a:hover{text-decoration:underline}
-code,.mono{font-family:'SF Mono',Consolas,'Liberation Mono',Menlo,monospace}
+code,.mono{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 .container{max-width:1152px;margin:0 auto;padding:0 16px;width:100%}
 @media(min-width:640px){.container{padding:0 24px}}
 
 /* Header */
-.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #1a1a1a}
+.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #333}
 .header-inner{display:flex;align-items:center;justify-content:space-between;height:64px}
 .logo-link{display:flex;align-items:center;gap:8px}
 .logo-link:hover{text-decoration:none}
-.site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',Consolas,monospace}
+.site-name{font-size:18px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 .logo-link:hover .site-name{color:#f7931a}
 nav{display:flex;align-items:center;gap:4px}
 .nav-link{display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;color:#a0a0a0;transition:all .15s}
@@ -46,13 +46,13 @@ nav{display:flex;align-items:center;gap:4px}
 .section-title{font-size:24px;font-weight:700;color:#fff;margin-top:48px;margin-bottom:24px}
 
 /* Footer */
-.footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+.footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
 .footer-inner{display:flex;flex-direction:column;align-items:center;gap:16px}
 @media(min-width:640px){.footer-inner{flex-direction:row;justify-content:space-between}}
 .footer-links{display:flex;align-items:center;gap:16px}
 .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color .15s}
 .footer-link:hover{color:#fff;text-decoration:none}
-.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a}
+.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #333}
 
 /* Scrollbar */
 ::-webkit-scrollbar{width:8px;height:8px}

--- a/static/logos.html
+++ b/static/logos.html
@@ -11,7 +11,7 @@ html{scrollbar-gutter:stable}
 :focus-visible{outline:2px solid #f7931a;outline-offset:2px}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:#0f0f0f;color:#e0e0e0;min-height:100vh;display:flex;flex-direction:column;
+  background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
   line-height:1.6;
 }
 a{color:#f7931a;text-decoration:none}
@@ -58,7 +58,7 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
-::-webkit-scrollbar-thumb:hover{background:#555}
+::-webkit-scrollbar-thumb:hover{background:#666}
 /* Network banner */
 .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
 .network-banner-testnet{background:#7c3aed;color:#fff}

--- a/static/logos.html
+++ b/static/logos.html
@@ -59,16 +59,10 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
 ::-webkit-scrollbar-thumb:hover{background:#666}
-/* Network banner */
-.network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-.network-banner-testnet{background:#7c3aed;color:#fff}
-.network-banner-signet{background:#2563eb;color:#fff}
-.network-banner-regtest{background:#059669;color:#fff}
+
 </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
-
 <!-- Header -->
 <header class="header">
 <div class="container header-inner">

--- a/static/result.html
+++ b/static/result.html
@@ -25,12 +25,12 @@
     a:hover { text-decoration: underline; }
 
     /* Header */
-    .header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #1a1a1a}
+    .header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #333}
     .header-inner{max-width:1152px;margin:0 auto;padding:0 16px;display:flex;align-items:center;justify-content:space-between;height:64px}
     @media(min-width:640px){.header-inner{padding:0 24px}}
     .logo-link{display:flex;align-items:center;gap:8px;text-decoration:none}
     .logo-link:hover{text-decoration:none}
-    .site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',Consolas,monospace}
+    .site-name{font-size:18px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
     .logo-link:hover .site-name{color:#f7931a}
     .header-nav{display:flex;align-items:center;gap:4px}
     .nav-link{display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;color:#a0a0a0;transition:all .15s}
@@ -83,7 +83,7 @@
       gap: 8px;
     }
     .txid-text {
-      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-family: ui-monospace,'Cascadia Code','Fira Code',monospace;
       font-size: 14px;
       color: #a0a0a0;
       word-break: break-all;
@@ -337,7 +337,7 @@
     }
 
     /* Footer */
-    .footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+    .footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
     .footer-container{max-width:1152px;margin:0 auto;padding:0 16px}
     @media(min-width:640px){.footer-container{padding:0 24px}}
     .footer-inner{display:flex;flex-direction:column;align-items:center;gap:16px}
@@ -345,7 +345,7 @@
     .footer-links{display:flex;align-items:center;gap:16px}
     .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color .15s}
     .footer-link:hover{color:#fff;text-decoration:none}
-    .footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a}
+    .footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #333}
 
     /* Loading */
     .loading-container {
@@ -462,7 +462,7 @@
 <div class="footer-container">
   <div class="footer-inner">
     <div>
-      <p style="font-size:14px;color:#a0a0a0"><span style="color:#fff;font-weight:500;font-family:'SF Mono',Consolas,monospace" id="footer-site-name"></span> - Bitcoin raw transaction broadcast service</p>
+      <p style="font-size:14px;color:#a0a0a0"><span style="color:#fff;font-weight:500;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace" id="footer-site-name"></span> - Bitcoin raw transaction broadcast service</p>
       <p style="font-size:12px;color:#666;margin-top:4px">Specializing in non-standard transactions that other services reject</p>
     </div>
     <div class="footer-links">

--- a/static/result.html
+++ b/static/result.html
@@ -430,15 +430,10 @@
     ::-webkit-scrollbar-track{background:#0f0f0f}
     ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
     ::-webkit-scrollbar-thumb:hover{background:#555}
-    .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-    .network-banner-testnet{background:#7c3aed;color:#fff}
-    .network-banner-signet{background:#2563eb;color:#fff}
-    .network-banner-regtest{background:#059669;color:#fff}
+
   </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
-
 <header class="header">
 <div class="header-inner">
   <a href="/" class="logo-link">

--- a/static/result.html
+++ b/static/result.html
@@ -13,7 +13,7 @@
 
     body {
       background: #0f0f0f;
-      color: #e0e0e0;
+      color: #fff;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       line-height: 1.6;
       min-height: 100vh;
@@ -113,18 +113,16 @@
       padding: 2px 8px;
       border-radius: 6px;
       font-size: 12px;
-      font-weight: 600;
+      font-weight: 500;
       flex-shrink: 0;
     }
     .badge-success {
-      background: rgba(34, 197, 94, 0.15);
+      background: rgba(34, 197, 94, 0.12);
       color: #22c55e;
-      border: 1px solid rgba(34, 197, 94, 0.3);
     }
     .badge-error {
-      background: rgba(239, 68, 68, 0.15);
+      background: rgba(239, 68, 68, 0.12);
       color: #ef4444;
-      border: 1px solid rgba(239, 68, 68, 0.3);
     }
 
     /* Cards */
@@ -134,10 +132,9 @@
       border-radius: 12px;
       padding: 24px;
       margin-bottom: 24px;
-      box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
     }
     .card-title {
-      font-size: 16px;
+      font-size: 18px;
       font-weight: 600;
       color: #fff;
       margin-bottom: 16px;
@@ -156,17 +153,17 @@
     }
     .acceptance-bar-track {
       width: 100%;
-      height: 8px;
-      background: #333;
-      border-radius: 4px;
+      height: 12px;
+      background: #252525;
+      border-radius: 9999px;
       overflow: hidden;
       position: relative;
     }
     .acceptance-bar-fill {
       height: 100%;
       background: #22c55e;
-      border-radius: 6px;
-      transition: width 0.6s ease;
+      border-radius: 9999px;
+      transition: width 0.5s;
     }
 
     /* Endpoint list */
@@ -230,11 +227,10 @@
     }
     .difficulty-badge {
       display: inline-block;
-      padding: 2px 10px;
-      border-radius: 12px;
+      padding: 4px 10px;
+      border-radius: 6px;
       font-size: 14px;
-      font-weight: 600;
-      text-transform: capitalize;
+      font-weight: 500;
     }
     .standard-yes { color: #22c55e; }
     .standard-no { color: #ef4444; }
@@ -254,12 +250,10 @@
       display: inline-block;
       background: rgba(234, 179, 8, 0.12);
       color: #eab308;
-      border: 1px solid rgba(234, 179, 8, 0.25);
-      border-radius: 4px;
-      padding: 3px 10px;
+      border-radius: 6px;
+      padding: 2px 8px;
       font-size: 12px;
       margin: 0 6px 6px 0;
-      font-family: 'SF Mono', 'Fira Code', monospace;
     }
 
     /* Service comparison */

--- a/static/status.html
+++ b/static/status.html
@@ -11,7 +11,7 @@ html{scrollbar-gutter:stable}
 :focus-visible{outline:2px solid #f7931a;outline-offset:2px}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:#0f0f0f;color:#e0e0e0;min-height:100vh;display:flex;flex-direction:column;
+  background:#0f0f0f;color:#fff;min-height:100vh;display:flex;flex-direction:column;
   line-height:1.6;
 }
 a{color:#f7931a;text-decoration:none}
@@ -49,7 +49,7 @@ nav{display:flex;align-items:center;gap:4px}
 .btn-secondary svg{margin-right:8px}
 
 /* Cards — matches React Card variant="bordered" */
-.card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px;box-shadow:0 4px 6px -1px rgb(0 0 0/.3),0 2px 4px -2px rgb(0 0 0/.3)}
+.card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:24px}
 .card-header{margin-bottom:16px}
 .card-title{font-size:18px;font-weight:600;color:#fff;display:flex;align-items:center;gap:8px}
 .card-content{color:#a0a0a0}
@@ -119,7 +119,7 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
-::-webkit-scrollbar-thumb:hover{background:#555}
+::-webkit-scrollbar-thumb:hover{background:#666}
 .network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
 .network-banner-testnet{background:#7c3aed;color:#fff}
 .network-banner-signet{background:#2563eb;color:#fff}

--- a/static/status.html
+++ b/static/status.html
@@ -16,15 +16,15 @@ body{
 }
 a{color:#f7931a;text-decoration:none}
 a:hover{text-decoration:underline}
-code,.mono{font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace}
+code,.mono{font-family:ui-monospace,'Cascadia Code','Fira Code',monospace}
 
 /* Header */
-.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #1a1a1a}
+.header{position:sticky;top:0;z-index:50;background:rgba(15,15,15,.95);backdrop-filter:blur(8px);border-bottom:1px solid #333}
 .header-inner{max-width:1152px;margin:0 auto;padding:0 16px;display:flex;align-items:center;justify-content:space-between;height:64px}
 @media(min-width:640px){.header-inner{padding:0 24px}}
 .logo-link{display:flex;align-items:center;gap:8px}
 .logo-link:hover{text-decoration:none}
-.site-name{font-size:18px;font-weight:700;color:#fff;font-family:'SF Mono',SFMono-Regular,Consolas,monospace;transition:color .15s}
+.site-name{font-size:18px;font-weight:700;color:#fff;font-family:ui-monospace,'Cascadia Code','Fira Code',monospace;transition:color .15s}
 .logo-link:hover .site-name{color:#f7931a}
 nav{display:flex;align-items:center;gap:4px}
 .nav-link{display:flex;align-items:center;gap:8px;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;color:#a0a0a0;transition:all .15s}
@@ -107,7 +107,7 @@ nav{display:flex;align-items:center;gap:4px}
 .spinning{animation:spin 1s linear infinite}
 
 /* Footer */
-.footer{margin-top:auto;border-top:1px solid #1a1a1a;background:#0f0f0f;padding:32px 0}
+.footer{margin-top:auto;border-top:1px solid #333;background:#0f0f0f;padding:32px 0}
 .footer-container{max-width:1152px;margin:0 auto;padding:0 16px}
 @media(min-width:640px){.footer-container{padding:0 24px}}
 .footer-inner{display:flex;flex-direction:column;align-items:center;gap:16px}
@@ -115,7 +115,7 @@ nav{display:flex;align-items:center;gap:4px}
 .footer-links{display:flex;align-items:center;gap:16px}
 .footer-link{display:flex;align-items:center;gap:8px;font-size:14px;color:#a0a0a0;transition:color .15s}
 .footer-link:hover{color:#fff;text-decoration:none}
-.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #1a1a1a}
+.footer-credit{font-size:12px;color:#666;text-align:center;margin-top:24px;padding-top:24px;border-top:1px solid #333}
 ::-webkit-scrollbar{width:8px;height:8px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}

--- a/static/status.html
+++ b/static/status.html
@@ -120,15 +120,10 @@ nav{display:flex;align-items:center;gap:4px}
 ::-webkit-scrollbar-track{background:#0f0f0f}
 ::-webkit-scrollbar-thumb{background:#333;border-radius:4px}
 ::-webkit-scrollbar-thumb:hover{background:#666}
-.network-banner{padding:8px 16px;text-align:center;font-size:13px;font-weight:600;letter-spacing:0.5px}
-.network-banner-testnet{background:#7c3aed;color:#fff}
-.network-banner-signet{background:#2563eb;color:#fff}
-.network-banner-regtest{background:#059669;color:#fff}
+
 </style>
 </head>
 <body>
-<!-- NETWORK_BANNER -->
-
 <!-- Header -->
 <header class="header">
 <div class="header-inner">


### PR DESCRIPTION
## Summary

- **CSS parity**: Match React frontend styles across all 7 HTML pages (body color, card shadows, badge styling, button weights, scrollbar colors, textarea, acceptance bars, feature tags)
- **Weight calculation fix**: Correct SegWit TX weight using actual witness byte tracking instead of approximation (was ~20% overestimate)
- **Remove server-side banner injection**: Strip all `get_banner_html()`, `inject_banner()`, placeholder replacement, and `window.__NETWORK__` injection from `static_files.c`. Server now serves HTML files byte-for-byte with zero modification.
- **Client-side network selector**: Add dropdown (mainnet/testnet/signet/regtest) to index.html persisted in localStorage. Address encoding uses selected network HRP. Top banner bar appears for non-mainnet selections.
- **Clean up non-TX pages**: Remove banner CSS and placeholders from docs, status, error, logos, result pages (banners don't help on pages without TX input)

## Commits

1. `e35717c` — Add missing CSS parity fixes across all 7 HTML pages
2. `a8f817b` — Add custom scrollbar styling and show broadcast button on load
3. `2ee41a2` — Fix TX weight calculation and chain banner cleanup
4. `53ae8f3` — Visual parity: match React CSS across all pages
5. `5ee25a8` — Remove server-side banner injection, move to client-side network selector

## Test plan

- [ ] Compare C server (port 8080) against React frontend (port 5173) for visual parity
- [ ] Verify network selector dropdown appears next to mode toggle on home page
- [ ] Switch to testnet/signet/regtest — top banner should appear with correct color
- [ ] Paste TX hex — addresses should encode with selected network's HRP
- [ ] Verify docs, status, error, logos pages have no banner elements
- [ ] Build with `make -j$(nproc)` — should compile clean with `-Werror`
- [ ] Supersedes PR #24