### PR TITLE
Add Grafana dashboard and Prometheus alert rules

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -372,11 +372,24 @@ scrape_configs:
       - targets: ['localhost:8080']
 ```
 
-Key metrics to alert on:
-- `rawrelay_tls_cert_expiry_timestamp_seconds` — alert when < 7 days
-- `rawrelay_connections_rejected_total{reason="slot_limit"}` — capacity pressure
-- `rawrelay_connections_rejected_total{reason="rate_limit"}` — abuse detection
-- `rawrelay_http_requests_by_class_total{class="5xx"}` — server errors
+Pre-built alerting rules are in [`contrib/prometheus/alerts.yml`](contrib/prometheus/alerts.yml) — covers cert expiry, slot pressure, error rate spikes, rate limit storms, FD exhaustion, and latency. Add to your Prometheus config:
+
+```yaml
+rule_files:
+  - /path/to/alerts.yml
+```
+
+### Grafana
+
+Import [`contrib/grafana/rawrelay-dashboard.json`](contrib/grafana/rawrelay-dashboard.json) into Grafana (Dashboards > Import > Upload JSON). Panels:
+
+- **Overview row**: request rate, active connections, error rate, TLS cert expiry, uptime, rejections
+- **Traffic row**: request rate by worker (stacked), HTTP status codes (color-coded), latency percentiles (p50/p90/p99), latency heatmap
+- **Connections row**: active connections by worker, rejections by reason (rate limit / slot limit / blocked), slot usage by tier (bar gauge with green/yellow/red)
+- **TLS & HTTP/2 row**: TLS handshakes by version (1.2 vs 1.3), TLS errors, HTTP/2 streams (active, new, RST_STREAM, GOAWAY)
+- **Resources row**: file descriptors (open vs max), rate limiter table size per worker, errors by type (timeout / parse / TLS)
+
+The dashboard has template variables for data source, instance, and worker — works with multi-instance and multi-worker setups out of the box.
 
 See [OPERATIONS.md](OPERATIONS.md) for the full metrics reference.
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ See [TESTING.md](TESTING.md) for the full testing strategy (sanitizers, fuzzing,
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Build instructions, code style, PR process |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting policy |
 | `config.ini.example` | All configuration options with inline docs |
+| `contrib/grafana/` | Grafana dashboard JSON (import to visualize all metrics) |
+| `contrib/prometheus/` | Prometheus alerting rules (cert expiry, error rate, slot pressure) |
 
 ## License
 

--- a/contrib/grafana/rawrelay-dashboard.json
+++ b/contrib/grafana/rawrelay-dashboard.json
@@ -1,0 +1,460 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source for RawRelay metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "9.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus" },
+    { "type": "panel", "id": "timeseries", "name": "Time series" },
+    { "type": "panel", "id": "stat", "name": "Stat" },
+    { "type": "panel", "id": "gauge", "name": "Gauge" },
+    { "type": "panel", "id": "bargauge", "name": "Bar gauge" },
+    { "type": "panel", "id": "heatmap", "name": "Heatmap" },
+    { "type": "panel", "id": "table", "name": "Table" }
+  ],
+  "id": null,
+  "uid": "rawrelay-overview",
+  "title": "RawRelay",
+  "description": "Bitcoin transaction relay server monitoring",
+  "tags": ["rawrelay", "bitcoin"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      },
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(rawrelay_requests_total, instance)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": { "selected": true, "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "worker",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(rawrelay_requests_total{instance=~\"$instance\"}, worker)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": { "selected": true, "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+
+    {
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "Request Rate",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 1000 }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" }
+    },
+
+    {
+      "title": "Active Connections",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "targets": [
+        { "expr": "sum(rawrelay_active_connections{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 400 }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" }
+    },
+
+    {
+      "title": "Error Rate (5xx)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_http_requests_by_class_total{instance=~\"$instance\", worker=~\"$worker\", class=\"5xx\"}[5m]))", "legendFormat": "" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 10 }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" }
+    },
+
+    {
+      "title": "TLS Cert Expiry",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [
+        { "expr": "min((rawrelay_tls_cert_expiry_timestamp_seconds{instance=~\"$instance\", worker=~\"$worker\"} - time()) / 86400)", "legendFormat": "" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "decimals": 0,
+          "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 7 }, { "color": "green", "value": 30 }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" }
+    },
+
+    {
+      "title": "Uptime",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "targets": [
+        { "expr": "max(rawrelay_process_uptime_seconds{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": { "steps": [{ "color": "green", "value": null }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "none", "graphMode": "none" }
+    },
+
+    {
+      "title": "Rejections/s",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_connections_rejected_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 5 }, { "color": "red", "value": 50 }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" }
+    },
+
+    {
+      "title": "Traffic",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "Request Rate by Worker",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        { "expr": "rate(rawrelay_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[1m])", "legendFormat": "worker {{worker}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+
+    {
+      "title": "HTTP Status Codes",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "sum by (status) (rate(rawrelay_http_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{status}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "200" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "400" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "404" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "408" }, "properties": [{ "id": "color", "value": { "fixedColor": "purple", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "429" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "503" }, "properties": [{ "id": "color", "value": { "fixedColor": "dark-red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "Request Latency (P50 / P90 / P99)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[5m])))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.90, sum by (le) (rate(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[5m])))", "legendFormat": "p90" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[5m])))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "fillOpacity": 10 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "p50" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "p90" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "p99" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "Latency Heatmap",
+      "type": "heatmap",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "targets": [
+        { "expr": "sum(increase(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[$__rate_interval])) by (le)", "legendFormat": "{{le}}", "format": "heatmap" }
+      ],
+      "options": {
+        "calculate": false,
+        "yAxis": { "unit": "s" },
+        "color": { "scheme": "Oranges", "mode": "scheme" },
+        "cellGap": 1
+      }
+    },
+
+    {
+      "title": "Connections",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "Active Connections by Worker",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 23 },
+      "targets": [
+        { "expr": "rawrelay_active_connections{instance=~\"$instance\", worker=~\"$worker\"}", "legendFormat": "worker {{worker}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+
+    {
+      "title": "Rejections by Reason",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 23 },
+      "targets": [
+        { "expr": "sum by (reason) (rate(rawrelay_connections_rejected_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{reason}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "rate_limit" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "slot_limit" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "blocked" }, "properties": [{ "id": "color", "value": { "fixedColor": "purple", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "Slot Usage by Tier",
+      "type": "bargauge",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 23 },
+      "targets": [
+        { "expr": "sum by (tier) (rawrelay_slots_used{instance=~\"$instance\", worker=~\"$worker\"}) / sum by (tier) (rawrelay_slots_max{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "{{tier}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.7 }, { "color": "red", "value": 0.9 }] }
+        }
+      },
+      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+
+    {
+      "title": "TLS & HTTP/2",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "TLS Handshakes by Version",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 32 },
+      "targets": [
+        { "expr": "sum by (protocol) (rate(rawrelay_tls_handshakes_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{protocol}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "TLSv1.3" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "TLSv1.2" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "TLS Errors",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 32 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_tls_handshake_errors_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "handshake errors" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 },
+          "color": { "fixedColor": "red", "mode": "fixed" }
+        }
+      }
+    },
+
+    {
+      "title": "HTTP/2 Streams",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
+      "targets": [
+        { "expr": "sum(rawrelay_http2_streams_active{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "active streams" },
+        { "expr": "sum(rate(rawrelay_http2_streams_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "new streams/s" },
+        { "expr": "sum(rate(rawrelay_http2_rst_stream_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "RST_STREAM/s" },
+        { "expr": "sum(rate(rawrelay_http2_goaway_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "GOAWAY/s" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 10 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "RST_STREAM/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "GOAWAY/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "Resources",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "File Descriptors",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 41 },
+      "targets": [
+        { "expr": "sum(rawrelay_open_fds{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "open" },
+        { "expr": "sum(rawrelay_max_fds{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "max" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 10 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "max" }, "properties": [{ "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } }, { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "open" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "Rate Limiter Table Size",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 41 },
+      "targets": [
+        { "expr": "rawrelay_rate_limiter_entries{instance=~\"$instance\", worker=~\"$worker\"}", "legendFormat": "worker {{worker}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 20 }
+        }
+      }
+    },
+
+    {
+      "title": "Errors by Type",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 41 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_errors_total{instance=~\"$instance\", worker=~\"$worker\", type=\"timeout\"}[1m]))", "legendFormat": "timeout" },
+        { "expr": "sum(rate(rawrelay_errors_total{instance=~\"$instance\", worker=~\"$worker\", type=\"parse_error\"}[1m]))", "legendFormat": "parse error" },
+        { "expr": "sum(rate(rawrelay_errors_total{instance=~\"$instance\", worker=~\"$worker\", type=\"tls_error\"}[1m]))", "legendFormat": "TLS error" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "timeout" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "parse error" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "TLS error" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    }
+  ]
+}

--- a/contrib/grafana/rawrelay-dashboard.json
+++ b/contrib/grafana/rawrelay-dashboard.json
@@ -78,7 +78,7 @@
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
       "targets": [
-        { "expr": "sum(rate(rawrelay_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "" }
+        { "expr": "sum(rate(rawrelay_http_requests_by_class_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "" }
       ],
       "fieldConfig": {
         "defaults": {
@@ -223,10 +223,68 @@
     },
 
     {
+      "title": "Requests by Endpoint",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 14 },
+      "targets": [
+        { "expr": "sum by (endpoint) (rate(rawrelay_endpoint_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{endpoint}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+
+    {
+      "title": "Requests by Method",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 14 },
+      "targets": [
+        { "expr": "sum by (method) (rate(rawrelay_requests_by_method_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{method}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "GET" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "POST" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "OTHER" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "Connections Accepted/s",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 14 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_connections_accepted_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "accepted" },
+        { "expr": "sum(rate(rawrelay_connections_rejected_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "rejected" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": { "fillOpacity": 20 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "accepted" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "rejected" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
       "title": "Request Latency (P50 / P90 / P99)",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
       "targets": [
         { "expr": "histogram_quantile(0.50, sum by (le) (rate(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[5m])))", "legendFormat": "p50" },
         { "expr": "histogram_quantile(0.90, sum by (le) (rate(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[5m])))", "legendFormat": "p90" },
@@ -249,7 +307,7 @@
       "title": "Latency Heatmap",
       "type": "heatmap",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
       "targets": [
         { "expr": "sum(increase(rawrelay_request_duration_seconds_bucket{instance=~\"$instance\", worker=~\"$worker\"}[$__rate_interval])) by (le)", "legendFormat": "{{le}}", "format": "heatmap" }
       ],
@@ -264,7 +322,7 @@
     {
       "title": "Connections",
       "type": "row",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
       "collapsed": false,
       "panels": []
     },
@@ -273,7 +331,7 @@
       "title": "Active Connections by Worker",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 23 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 31 },
       "targets": [
         { "expr": "rawrelay_active_connections{instance=~\"$instance\", worker=~\"$worker\"}", "legendFormat": "worker {{worker}}" }
       ],
@@ -288,7 +346,7 @@
       "title": "Rejections by Reason",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 23 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 31 },
       "targets": [
         { "expr": "sum by (reason) (rate(rawrelay_connections_rejected_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{reason}}" }
       ],
@@ -309,7 +367,7 @@
       "title": "Slot Usage by Tier",
       "type": "bargauge",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 23 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 31 },
       "targets": [
         { "expr": "sum by (tier) (rawrelay_slots_used{instance=~\"$instance\", worker=~\"$worker\"}) / sum by (tier) (rawrelay_slots_max{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "{{tier}}" }
       ],
@@ -327,7 +385,7 @@
     {
       "title": "TLS & HTTP/2",
       "type": "row",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
       "collapsed": false,
       "panels": []
     },
@@ -336,7 +394,7 @@
       "title": "TLS Handshakes by Version",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 40 },
       "targets": [
         { "expr": "sum by (protocol) (rate(rawrelay_tls_handshakes_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "{{protocol}}" }
       ],
@@ -356,7 +414,7 @@
       "title": "TLS Errors",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 40 },
       "targets": [
         { "expr": "sum(rate(rawrelay_tls_handshake_errors_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "handshake errors" }
       ],
@@ -373,7 +431,7 @@
       "title": "HTTP/2 Streams",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 40 },
       "targets": [
         { "expr": "sum(rawrelay_http2_streams_active{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "active streams" },
         { "expr": "sum(rate(rawrelay_http2_streams_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "new streams/s" },
@@ -394,7 +452,7 @@
     {
       "title": "Resources",
       "type": "row",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 48 },
       "collapsed": false,
       "panels": []
     },
@@ -403,7 +461,7 @@
       "title": "File Descriptors",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 41 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 49 },
       "targets": [
         { "expr": "sum(rawrelay_open_fds{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "open" },
         { "expr": "sum(rawrelay_max_fds{instance=~\"$instance\", worker=~\"$worker\"})", "legendFormat": "max" }
@@ -423,7 +481,7 @@
       "title": "Rate Limiter Table Size",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 41 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 49 },
       "targets": [
         { "expr": "rawrelay_rate_limiter_entries{instance=~\"$instance\", worker=~\"$worker\"}", "legendFormat": "worker {{worker}}" }
       ],
@@ -438,7 +496,7 @@
       "title": "Errors by Type",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 41 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 49 },
       "targets": [
         { "expr": "sum(rate(rawrelay_errors_total{instance=~\"$instance\", worker=~\"$worker\", type=\"timeout\"}[1m]))", "legendFormat": "timeout" },
         { "expr": "sum(rate(rawrelay_errors_total{instance=~\"$instance\", worker=~\"$worker\", type=\"parse_error\"}[1m]))", "legendFormat": "parse error" },
@@ -460,7 +518,7 @@
     {
       "title": "Bitcoin RPC",
       "type": "row",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
       "collapsed": false,
       "panels": []
     },
@@ -469,7 +527,7 @@
       "title": "Broadcast Rate",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 50 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 58 },
       "targets": [
         { "expr": "sum(rate(rawrelay_rpc_broadcasts_success_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "success" },
         { "expr": "sum(rate(rawrelay_rpc_broadcasts_failed_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "failed" }
@@ -490,7 +548,7 @@
       "title": "RPC Requests by Chain",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 50 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 58 },
       "targets": [
         { "expr": "sum by (chain) (rate(rawrelay_rpc_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "{{chain}}" }
       ],
@@ -506,7 +564,7 @@
       "title": "Node Availability",
       "type": "stat",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 50 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 58 },
       "targets": [
         { "expr": "rawrelay_rpc_node_up{instance=~\"$instance\", worker=~\"$worker\"}", "legendFormat": "{{chain}}" }
       ],
@@ -522,7 +580,7 @@
     {
       "title": "Security & Efficiency",
       "type": "row",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 58 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 66 },
       "collapsed": false,
       "panels": []
     },
@@ -531,7 +589,7 @@
       "title": "Bandwidth",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 59 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 67 },
       "targets": [
         { "expr": "sum(rate(rawrelay_response_bytes_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "bytes/s" }
       ],
@@ -548,7 +606,7 @@
       "title": "Slowloris Kills",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 59 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 67 },
       "targets": [
         { "expr": "sum(rate(rawrelay_slowloris_kills_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "kills/s" }
       ],
@@ -565,7 +623,7 @@
       "title": "Keep-Alive Reuse & Slot Failures",
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 59 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 67 },
       "targets": [
         { "expr": "sum(rate(rawrelay_keepalive_reuses_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "keepalive reuses" },
         { "expr": "sum(rate(rawrelay_slot_promotion_failures_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "slot promotion failures" }

--- a/contrib/grafana/rawrelay-dashboard.json
+++ b/contrib/grafana/rawrelay-dashboard.json
@@ -455,6 +455,131 @@
           { "matcher": { "id": "byName", "options": "TLS error" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
         ]
       }
+    },
+
+    {
+      "title": "Bitcoin RPC",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "Broadcast Rate",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 50 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_rpc_broadcasts_success_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "success" },
+        { "expr": "sum(rate(rawrelay_rpc_broadcasts_failed_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "failed" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "failed" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+
+    {
+      "title": "RPC Requests by Chain",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 50 },
+      "targets": [
+        { "expr": "sum by (chain) (rate(rawrelay_rpc_requests_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "{{chain}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 }
+        }
+      }
+    },
+
+    {
+      "title": "Node Availability",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 50 },
+      "targets": [
+        { "expr": "rawrelay_rpc_node_up{instance=~\"$instance\", worker=~\"$worker\"}", "legendFormat": "{{chain}}" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }],
+          "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "orientation": "horizontal" }
+    },
+
+    {
+      "title": "Security & Efficiency",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 58 },
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "title": "Bandwidth",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 59 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_response_bytes_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "bytes/s" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "fillOpacity": 20 },
+          "color": { "fixedColor": "blue", "mode": "fixed" }
+        }
+      }
+    },
+
+    {
+      "title": "Slowloris Kills",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 59 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_slowloris_kills_total{instance=~\"$instance\", worker=~\"$worker\"}[5m]))", "legendFormat": "kills/s" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 },
+          "color": { "fixedColor": "orange", "mode": "fixed" }
+        }
+      }
+    },
+
+    {
+      "title": "Keep-Alive Reuse & Slot Failures",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 59 },
+      "targets": [
+        { "expr": "sum(rate(rawrelay_keepalive_reuses_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "keepalive reuses" },
+        { "expr": "sum(rate(rawrelay_slot_promotion_failures_total{instance=~\"$instance\", worker=~\"$worker\"}[1m]))", "legendFormat": "slot promotion failures" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "keepalive reuses" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "slot promotion failures" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
     }
   ]
 }

--- a/contrib/prometheus/alerts.yml
+++ b/contrib/prometheus/alerts.yml
@@ -42,6 +42,7 @@ groups:
         expr: >
           rate(rawrelay_http_requests_by_class_total{class="5xx"}[5m])
           / rate(rawrelay_requests_total[5m]) > 0.05
+          and rate(rawrelay_requests_total[5m]) > 0
         for: 5m
         labels:
           severity: warning
@@ -127,6 +128,7 @@ groups:
         expr: >
           rate(rawrelay_rpc_broadcasts_failed_total[5m])
           / rate(rawrelay_rpc_broadcasts_total[5m]) > 0.1
+          and rate(rawrelay_rpc_broadcasts_total[5m]) > 0
         for: 5m
         labels:
           severity: warning

--- a/contrib/prometheus/alerts.yml
+++ b/contrib/prometheus/alerts.yml
@@ -1,0 +1,113 @@
+# RawRelay Prometheus Alerting Rules
+# Add to your Prometheus config:
+#   rule_files:
+#     - /path/to/alerts.yml
+
+groups:
+  - name: rawrelay
+    rules:
+
+      # TLS certificate expires in less than 7 days
+      - alert: RawRelayTLSCertExpiringSoon
+        expr: (rawrelay_tls_cert_expiry_timestamp_seconds - time()) < 604800
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS certificate expires in {{ $value | humanizeDuration }}"
+          description: "Certificate on worker {{ $labels.worker }} expires soon. Run certbot renew and send SIGUSR2."
+
+      # TLS certificate expires in less than 24 hours
+      - alert: RawRelayTLSCertCritical
+        expr: (rawrelay_tls_cert_expiry_timestamp_seconds - time()) < 86400
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS certificate expires in {{ $value | humanizeDuration }}"
+          description: "Certificate on worker {{ $labels.worker }} is about to expire. Immediate renewal required."
+
+      # Slot usage above 90% on any tier
+      - alert: RawRelaySlotPressure
+        expr: (rawrelay_slots_used / rawrelay_slots_max) > 0.9
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.tier }} slots at {{ $value | humanizePercentage }} on worker {{ $labels.worker }}"
+          description: "Connection slot tier {{ $labels.tier }} is nearly exhausted. Clients may receive 503."
+
+      # 5xx error rate above 5% of traffic sustained for 5 minutes
+      - alert: RawRelayHighErrorRate
+        expr: >
+          rate(rawrelay_http_requests_by_class_total{class="5xx"}[5m])
+          / rate(rawrelay_requests_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "5xx error rate at {{ $value | humanizePercentage }} on worker {{ $labels.worker }}"
+          description: "Sustained server error rate above 5%. Check logs with: journalctl -u rawrelay -f"
+
+      # Rate limit rejections sustained (possible attack or misconfigured limits)
+      - alert: RawRelayRateLimitStorm
+        expr: rate(rawrelay_connections_rejected_total{reason="rate_limit"}[5m]) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value | humanize }}/s rate-limited on worker {{ $labels.worker }}"
+          description: "Sustained rate limit rejections. May indicate abuse or rate limits set too low."
+
+      # Blocklist rejections sustained (possible attack)
+      - alert: RawRelayBlocklistStorm
+        expr: rate(rawrelay_connections_rejected_total{reason="blocked"}[5m]) > 10
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: "{{ $value | humanize }}/s blocked on worker {{ $labels.worker }}"
+          description: "Sustained blocked connection attempts from IPs on the blocklist."
+
+      # File descriptor usage above 80%
+      - alert: RawRelayFDPressure
+        expr: (rawrelay_open_fds / rawrelay_max_fds) > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "FD usage at {{ $value | humanizePercentage }} on worker {{ $labels.worker }}"
+          description: "File descriptors running low. Consider raising LimitNOFILE in the systemd unit."
+
+      # Scrape target down
+      - alert: RawRelayDown
+        expr: up{job="rawrelay"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RawRelay scrape target is down"
+          description: "Prometheus cannot reach the /metrics endpoint. Check: systemctl status rawrelay"
+
+      # TLS handshake errors sustained
+      - alert: RawRelayTLSErrors
+        expr: rate(rawrelay_tls_handshake_errors_total[5m]) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value | humanize }}/s TLS handshake errors on worker {{ $labels.worker }}"
+          description: "Sustained TLS handshake failures. May indicate misconfigured clients or cert issues."
+
+      # P99 latency above 1 second
+      - alert: RawRelayHighLatency
+        expr: >
+          histogram_quantile(0.99,
+            rate(rawrelay_request_duration_seconds_bucket[5m])
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P99 latency at {{ $value | humanizeDuration }} on worker {{ $labels.worker }}"
+          description: "99th percentile request latency is above 1 second. Check RPC connection and system load."

--- a/contrib/prometheus/alerts.yml
+++ b/contrib/prometheus/alerts.yml
@@ -111,3 +111,45 @@ groups:
         annotations:
           summary: "P99 latency at {{ $value | humanizeDuration }} on worker {{ $labels.worker }}"
           description: "99th percentile request latency is above 1 second. Check RPC connection and system load."
+
+      # Bitcoin node down
+      - alert: RawRelayRPCNodeDown
+        expr: rawrelay_rpc_node_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Bitcoin {{ $labels.chain }} node down on worker {{ $labels.worker }}"
+          description: "RPC connection to {{ $labels.chain }} node is unavailable. Check that bitcoind is running."
+
+      # Broadcast failure rate above 10%
+      - alert: RawRelayBroadcastFailures
+        expr: >
+          rate(rawrelay_rpc_broadcasts_failed_total[5m])
+          / rate(rawrelay_rpc_broadcasts_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Broadcast failure rate at {{ $value | humanizePercentage }} on worker {{ $labels.worker }}"
+          description: "More than 10% of transaction broadcasts are failing. Check Bitcoin node logs and RPC connectivity."
+
+      # Slowloris attacks detected
+      - alert: RawRelaySlowlorisAttack
+        expr: rate(rawrelay_slowloris_kills_total[5m]) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value | humanize }}/s slowloris kills on worker {{ $labels.worker }}"
+          description: "Sustained slowloris-style connections being killed. May indicate a slow-read attack."
+
+      # Slot promotion failures (large transactions can't get slots)
+      - alert: RawRelaySlotPromotionFailures
+        expr: rate(rawrelay_slot_promotion_failures_total[5m]) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value | humanize }}/s slot promotion failures on worker {{ $labels.worker }}"
+          description: "Large/huge tier slots exhausted. Large transactions are being rejected with 503. Consider increasing large_max/huge_max."

--- a/include/endpoints.h
+++ b/include/endpoints.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "router.h"
 
 /* Forward declarations */
 struct WorkerProcess;
@@ -63,6 +64,11 @@ void update_status_counters(struct WorkerProcess *worker, int status);
  * Update HTTP method counters.
  */
 void update_method_counters(struct WorkerProcess *worker, const char *method);
+
+/*
+ * Update per-endpoint request counters.
+ */
+void update_endpoint_counter(struct WorkerProcess *worker, RouteType route);
 
 /*
  * Log access entry for a completed request.

--- a/include/worker.h
+++ b/include/worker.h
@@ -134,6 +134,7 @@ typedef struct WorkerProcess {
     uint64_t endpoint_result;
     uint64_t endpoint_docs;
     uint64_t endpoint_status;
+    uint64_t endpoint_logos;
     uint64_t endpoint_acme;
 
     /* Extended metrics */

--- a/include/worker.h
+++ b/include/worker.h
@@ -123,6 +123,12 @@ typedef struct WorkerProcess {
     uint64_t errors_parse;
     uint64_t errors_tls;
 
+    /* Extended metrics */
+    uint64_t response_bytes_total;       /* Total response bytes sent */
+    uint64_t slowloris_kills;            /* Slowloris detections */
+    uint64_t slot_promotion_failures;    /* Tier promotion failures (no slots) */
+    uint64_t keepalive_reuses;           /* Requests served on reused connections */
+
     /* Active connections list (intrusive linked list) */
     struct Connection *connections;
 

--- a/include/worker.h
+++ b/include/worker.h
@@ -123,6 +123,19 @@ typedef struct WorkerProcess {
     uint64_t errors_parse;
     uint64_t errors_tls;
 
+    /* Per-endpoint counters */
+    uint64_t endpoint_health;
+    uint64_t endpoint_ready;
+    uint64_t endpoint_alive;
+    uint64_t endpoint_version;
+    uint64_t endpoint_metrics;
+    uint64_t endpoint_home;
+    uint64_t endpoint_broadcast;
+    uint64_t endpoint_result;
+    uint64_t endpoint_docs;
+    uint64_t endpoint_status;
+    uint64_t endpoint_acme;
+
     /* Extended metrics */
     uint64_t response_bytes_total;       /* Total response bytes sent */
     uint64_t slowloris_kills;            /* Slowloris detections */

--- a/src/connection.c
+++ b/src/connection.c
@@ -860,6 +860,7 @@ static void process_request(Connection *conn)
 
     /* Route the request based on path */
     RouteType route = route_request(conn->path, conn->path_len);
+    update_endpoint_counter(worker, route);
 
     /* Handle observability endpoints */
     switch (route) {

--- a/src/connection.c
+++ b/src/connection.c
@@ -1219,7 +1219,7 @@ static void log_request_complete(Connection *conn)
     update_status_counters(worker, conn->response_status);
     update_method_counters(worker, conn->method);
     worker->response_bytes_total += conn->response_bytes;
-    if (conn->requests_on_connection > 1) {
+    if (conn->requests_on_connection > 0) {
         worker->keepalive_reuses++;
     }
 

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -414,6 +414,7 @@ int generate_metrics_body(WorkerProcess *worker, char *buf, size_t bufsize)
         "rawrelay_endpoint_requests_total{worker=\"%d\",endpoint=\"/result\"} %lu\n"
         "rawrelay_endpoint_requests_total{worker=\"%d\",endpoint=\"/docs\"} %lu\n"
         "rawrelay_endpoint_requests_total{worker=\"%d\",endpoint=\"/status\"} %lu\n"
+        "rawrelay_endpoint_requests_total{worker=\"%d\",endpoint=\"/logos\"} %lu\n"
         "rawrelay_endpoint_requests_total{worker=\"%d\",endpoint=\"/acme\"} %lu\n",
         worker->worker_id, (unsigned long)worker->endpoint_health,
         worker->worker_id, (unsigned long)worker->endpoint_ready,
@@ -425,6 +426,7 @@ int generate_metrics_body(WorkerProcess *worker, char *buf, size_t bufsize)
         worker->worker_id, (unsigned long)worker->endpoint_result,
         worker->worker_id, (unsigned long)worker->endpoint_docs,
         worker->worker_id, (unsigned long)worker->endpoint_status,
+        worker->worker_id, (unsigned long)worker->endpoint_logos,
         worker->worker_id, (unsigned long)worker->endpoint_acme);
     METRICS_ADVANCE();
 
@@ -727,7 +729,7 @@ void update_endpoint_counter(WorkerProcess *worker, RouteType route)
         case ROUTE_RESULT:    worker->endpoint_result++; break;
         case ROUTE_DOCS:      worker->endpoint_docs++; break;
         case ROUTE_STATUS:    worker->endpoint_status++; break;
-        case ROUTE_LOGOS:     worker->endpoint_status++; break;
+        case ROUTE_LOGOS:     worker->endpoint_logos++; break;
         case ROUTE_ACME_CHALLENGE: worker->endpoint_acme++; break;
         case ROUTE_ERROR:     break;  /* tracked via 404 status counter */
     }

--- a/src/http2.c
+++ b/src/http2.c
@@ -377,6 +377,7 @@ static int h2_on_stream_close_callback(nghttp2_session *session,
             update_latency_histogram(worker, duration_sec);
             update_status_counters(worker, stream->response_status);
             update_method_counters(worker, stream->method);
+            worker->response_bytes_total += stream->response_bytes;
 
             log_request_access(conn->client_ip,
                                stream->method ? stream->method : "???",
@@ -486,6 +487,7 @@ static int h2_on_header_callback(nghttp2_session *session,
             if (!slot_manager_promote(&h2->worker->slots, stream->tier, required)) {
                 log_warn("HTTP/2: Cannot promote stream %d from %s to %s tier",
                          stream->stream_id, tier_name(stream->tier), tier_name(required));
+                h2->worker->slot_promotion_failures++;
                 /* Reject the stream with REFUSED_STREAM */
                 nghttp2_submit_rst_stream(session, NGHTTP2_FLAG_NONE,
                                           stream->stream_id, NGHTTP2_REFUSED_STREAM);

--- a/src/http2.c
+++ b/src/http2.c
@@ -206,6 +206,7 @@ static void h2_process_stream_request(Connection *conn, H2Stream *stream)
     H2Connection *h2 = conn->h2;
     WorkerProcess *worker = h2->worker;
     RouteType route = route_request(stream->path, stream->path_len);
+    update_endpoint_counter(worker, route);
     StaticFile *file;
     int status_code = 200;
     const char *content_type = "text/plain";

--- a/src/http2.c
+++ b/src/http2.c
@@ -233,7 +233,7 @@ static void h2_process_stream_request(Connection *conn, H2Stream *stream)
                              (const unsigned char *)"", 0);
             break;
         case ROUTE_METRICS: {
-            char body[8192];
+            char body[16384];
             int len = generate_metrics_body(worker, body, sizeof(body));
             status_code = 200;
             content_type = "text/plain; version=0.0.4; charset=utf-8";

--- a/tools/attack_demo.sh
+++ b/tools/attack_demo.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Sustained stress test for Grafana visualization
+# Uses apache bench (ab) for real sustained load
+# Each wave lasts 20-30s so Prometheus scrapes capture everything
+HOST=localhost
+HTTP=8080
+TLS=8443
+CONC=50  # concurrency for ab
+
+echo "============================================"
+echo "  RAWRELAY SUSTAINED ATTACK"
+echo "  Grafana: http://localhost:3000"
+echo "============================================"
+echo ""
+
+metric() {
+    curl -s http://$HOST:$HTTP/metrics 2>/dev/null | grep "^$1" | head -1 | awk '{print $2}' | cut -d. -f1
+}
+
+# ── WAVE 1: Sustained HTTP Flood (30s) ─────────
+echo "[WAVE 1/8] SUSTAINED HTTP FLOOD"
+echo "  ab: 10000 requests, 50 concurrent, ~30s sustained"
+echo "  >> Requests/sec, Bandwidth, Active Connections"
+ab -n 10000 -c $CONC -s 2 -q http://$HOST:$HTTP/health 2>&1 | grep -E "Requests per|Complete|Failed|Transfer rate"
+echo ""
+sleep 5
+
+# ── WAVE 2: Slot Saturation + Overflow (30s) ───
+echo "[WAVE 2/8] SLOT SATURATION"
+echo "  20 nc connections hold slots, then ab flood hits slot_limit wall"
+echo "  >> Slots Used fills to 15/15, Slot Rejections spike"
+# Hold 20 incomplete HTTP connections (only 15 slots available)
+for i in $(seq 1 20); do
+    (printf "GET /health HTTP/1.1\r\nHost: localhost\r\n"; sleep 30) | nc -w 31 $HOST $HTTP > /dev/null 2>&1 &
+done
+sleep 3
+SLOTS=$(metric 'rawrelay_slots_used{worker="0",tier="normal"}')
+echo "  Slots filled: ${SLOTS:-?}/15"
+# Now hammer while slots are full
+ab -n 2000 -c 20 -s 2 -q http://$HOST:$HTTP/health 2>&1 | grep -E "Requests per|Complete|Failed|Non-2xx"
+REJECTS=$(metric 'rawrelay_connections_rejected_total{worker="0",reason="slot_limit"}')
+echo "  Slot rejections so far: ${REJECTS:-0}"
+# Let the nc connections time out naturally
+sleep 10
+kill $(jobs -p) 2>/dev/null
+wait 2>/dev/null
+echo ""
+sleep 5
+
+# ── WAVE 3: Rate Limit Exhaustion (30s) ────────
+echo "[WAVE 3/8] RATE LIMIT STORM"
+echo "  ab: 5000 requests, 100 concurrent (rps=50, burst=100 => most rejected)"
+echo "  >> Rate Limit Rejections counter rockets"
+ab -n 5000 -c 100 -s 1 -q http://$HOST:$HTTP/health 2>&1 | grep -E "Requests per|Complete|Failed|Non-2xx"
+RATE_R=$(metric 'rawrelay_connections_rejected_total{worker="0",reason="rate_limit"}')
+echo "  Rate limit rejections so far: ${RATE_R:-0}"
+echo ""
+sleep 8
+
+# ── WAVE 4: Slowloris Siege (40s) ──────────────
+echo "[WAVE 4/8] SLOWLORIS SIEGE"
+echo "  10 connections drip-feeding 1 byte every 3 seconds"
+echo "  >> Slowloris Kills counter, Timeout errors"
+BEFORE=$(metric 'rawrelay_slowloris_kills_total{worker="0"}')
+for i in $(seq 1 10); do
+    (
+        printf "G"; sleep 3
+        printf "E"; sleep 3
+        printf "T"; sleep 3
+        printf " "; sleep 3
+        printf "/"; sleep 3
+        printf " "; sleep 25
+    ) | nc -w 30 $HOST $HTTP > /dev/null 2>&1 &
+done
+echo "  10 slowloris connections dripping..."
+# Meanwhile send normal traffic so dashboard stays active
+for round in $(seq 1 8); do
+    ab -n 100 -c 5 -s 2 -q http://$HOST:$HTTP/health > /dev/null 2>&1
+    sleep 3
+done
+AFTER=$(metric 'rawrelay_slowloris_kills_total{worker="0"}')
+KILLS=$(( ${AFTER:-0} - ${BEFORE:-0} ))
+echo "  Slowloris kills this wave: $KILLS"
+kill $(jobs -p) 2>/dev/null
+wait 2>/dev/null
+echo ""
+sleep 5
+
+# ── WAVE 5: TLS + HTTP/2 Storm (30s) ──────────
+echo "[WAVE 5/8] TLS + HTTP/2 STORM"
+echo "  50 concurrent TLS connections, sustained"
+echo "  >> TLS Handshakes, HTTP/2 Streams"
+# ab doesn't do TLS easily, use curl loops sustained over 20s
+END=$((SECONDS + 20))
+while [ $SECONDS -lt $END ]; do
+    for i in $(seq 1 10); do
+        curl -sk -o /dev/null --max-time 3 https://$HOST:$TLS/health &
+    done
+    sleep 1
+done
+wait
+TLS13=$(metric 'rawrelay_tls_handshakes_total{worker="0",protocol="TLSv1.3"}')
+H2=$(metric 'rawrelay_http2_streams_total{worker="0"}')
+echo "  TLS 1.3 handshakes: ${TLS13:-0}"
+echo "  HTTP/2 streams: ${H2:-0}"
+echo ""
+sleep 5
+
+# ── WAVE 6: Keepalive Saturation (20s) ────────
+echo "[WAVE 6/8] KEEPALIVE SATURATION"
+echo "  ab with keepalive (-k), 5000 requests on reused connections"
+echo "  >> Keepalive Reuses counter jumps massively"
+BEFORE_KA=$(metric 'rawrelay_keepalive_reuses_total{worker="0"}')
+ab -n 5000 -c 20 -k -s 2 -q http://$HOST:$HTTP/health 2>&1 | grep -E "Requests per|Complete|Keep-Alive"
+AFTER_KA=$(metric 'rawrelay_keepalive_reuses_total{worker="0"}')
+NEW_KA=$(( ${AFTER_KA:-0} - ${BEFORE_KA:-0} ))
+echo "  New keepalive reuses: $NEW_KA"
+echo ""
+sleep 5
+
+# ── WAVE 7: 404 Error Flood + Bandwidth (20s) ─
+echo "[WAVE 7/8] ERROR + BANDWIDTH FLOOD"
+echo "  Mix of valid pages (bandwidth) and 404s (error counters)"
+echo "  >> 4xx class spikes, Response Bytes climbs"
+# Fetch the homepage (big HTML) repeatedly for bandwidth
+ab -n 2000 -c 20 -s 2 -q http://$HOST:$HTTP/ > /dev/null 2>&1 &
+PID_BW=$!
+# Simultaneously hit 404s
+ab -n 2000 -c 20 -s 2 -q http://$HOST:$HTTP/nonexistent_page > /dev/null 2>&1 &
+PID_ERR=$!
+wait $PID_BW $PID_ERR
+BYTES=$(metric 'rawrelay_response_bytes_total{worker="0"}')
+FOUR=$(metric 'rawrelay_http_requests_by_class_total{worker="0",class="4xx"}')
+echo "  Total bytes served: ${BYTES:-0}"
+echo "  Total 4xx responses: ${FOUR:-0}"
+echo ""
+sleep 5
+
+# ── WAVE 8: TOTAL CHAOS (45s) ─────────────────
+echo "[WAVE 8/8] TOTAL CHAOS - everything simultaneously for 45 seconds"
+echo "  >> ALL charts spike at once"
+
+# Sustained HTTP flood
+ab -n 10000 -c 30 -s 2 -q http://$HOST:$HTTP/health > /dev/null 2>&1 &
+PID1=$!
+
+# Sustained keepalive flood
+ab -n 5000 -c 20 -k -s 2 -q http://$HOST:$HTTP/ > /dev/null 2>&1 &
+PID2=$!
+
+# Sustained 404s
+ab -n 3000 -c 10 -s 2 -q http://$HOST:$HTTP/chaos_404 > /dev/null 2>&1 &
+PID3=$!
+
+# Slot holders
+for i in $(seq 1 20); do
+    (printf "GET /health HTTP/1.1\r\nHost: localhost\r\n"; sleep 40) | nc -w 41 $HOST $HTTP > /dev/null 2>&1 &
+done
+
+# TLS storm
+END=$((SECONDS + 40))
+while [ $SECONDS -lt $END ]; do
+    for i in $(seq 1 5); do
+        curl -sk -o /dev/null --max-time 2 https://$HOST:$TLS/health &
+    done
+    sleep 2
+done &
+PID4=$!
+
+# Slowloris sprinkled in
+for i in $(seq 1 5); do
+    (printf "P"; sleep 3; printf "O"; sleep 3; printf "S"; sleep 30) | nc -w 35 $HOST $HTTP > /dev/null 2>&1 &
+done
+
+echo "  Chaos running for ~45 seconds..."
+sleep 45
+kill $(jobs -p) 2>/dev/null
+wait 2>/dev/null
+echo "  Chaos complete"
+
+echo ""
+echo "============================================"
+echo "  ATTACK COMPLETE - FINAL METRICS"
+echo "============================================"
+echo ""
+echo "--- Worker 0 ---"
+curl -s http://$HOST:$HTTP/metrics 2>/dev/null | grep -E '^rawrelay_(requests_total|connections_accepted|connections_rejected|keepalive|slowloris|tls_handshakes|http2_streams_total|slots_used|http_requests_by_class|response_bytes|errors_total)\{worker="0"' | sort
+echo ""
+echo "--- Worker 1 ---"
+curl -s http://$HOST:$HTTP/metrics 2>/dev/null | grep -E '^rawrelay_(requests_total|connections_accepted|connections_rejected|keepalive|slowloris|tls_handshakes|http2_streams_total|slots_used|http_requests_by_class|response_bytes|errors_total)\{worker="1"' | sort

--- a/tools/harden_test.sh
+++ b/tools/harden_test.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Industry-standard hardening test suite
+# Tools: slowhttptest, h2load, wrk, raw sockets
+HOST=localhost
+HTTP=8080
+TLS=8443
+
+metric() {
+    curl -s http://$HOST:$HTTP/metrics 2>/dev/null | grep "^$1" | head -1 | awk '{print $2}' | cut -d. -f1
+}
+
+echo "============================================"
+echo "  RAWRELAY HARDENING SUITE"
+echo "  Tools: slowhttptest, h2load, wrk, fuzz"
+echo "============================================"
+
+# ── TEST 1: wrk sustained load with latency stats ──
+echo ""
+echo "[1/9] WRK - Sustained HTTP load (30s)"
+echo "  200 connections, 4 threads, latency percentiles"
+wrk -t4 -c200 -d30s --latency http://$HOST:$HTTP/health
+sleep 5
+
+# ── TEST 2: wrk keepalive pipeline ─────────────────
+echo ""
+echo "[2/9] WRK - Keepalive pipeline (20s)"
+echo "  50 persistent connections hammering /"
+BEFORE_KA=$(metric 'rawrelay_keepalive_reuses_total{worker="0"}')
+wrk -t2 -c50 -d20s http://$HOST:$HTTP/
+AFTER_KA=$(metric 'rawrelay_keepalive_reuses_total{worker="0"}')
+echo "  Keepalive reuses this wave: $(( ${AFTER_KA:-0} - ${BEFORE_KA:-0} ))"
+sleep 5
+
+# ── TEST 3: slowhttptest - Slowloris mode ──────────
+echo ""
+echo "[3/9] SLOWHTTPTEST - Slowloris mode (30s)"
+echo "  200 connections, send 1 byte every 10 seconds"
+echo "  Server should kill these before they exhaust slots"
+BEFORE_SL=$(metric 'rawrelay_slowloris_kills_total{worker="0"}')
+slowhttptest -c 200 -H -g -o /tmp/slowloris_results \
+    -i 10 -r 50 -t GET -u http://$HOST:$HTTP/health \
+    -l 30 -p 3 2>&1 | tail -5
+AFTER_SL=$(metric 'rawrelay_slowloris_kills_total{worker="0"}')
+echo "  Slowloris kills: $(( ${AFTER_SL:-0} - ${BEFORE_SL:-0} ))"
+sleep 5
+
+# ── TEST 4: slowhttptest - Slow POST body ─────────
+echo ""
+echo "[4/9] SLOWHTTPTEST - Slow POST body (30s)"
+echo "  Sends Content-Length then drips body 1 byte/10s"
+BEFORE_TO=$(metric 'rawrelay_errors_total{worker="0",type="timeout"}')
+slowhttptest -c 200 -B -g -o /tmp/slowpost_results \
+    -i 10 -r 50 -t POST -u http://$HOST:$HTTP/api/tx \
+    -l 30 -p 3 2>&1 | tail -5
+AFTER_TO=$(metric 'rawrelay_errors_total{worker="0",type="timeout"}')
+echo "  Timeouts: $(( ${AFTER_TO:-0} - ${BEFORE_TO:-0} ))"
+sleep 5
+
+# ── TEST 5: slowhttptest - Slow Read ──────────────
+echo ""
+echo "[5/9] SLOWHTTPTEST - Slow Read attack (30s)"
+echo "  Reads response as slowly as possible"
+slowhttptest -c 200 -X -g -o /tmp/slowread_results \
+    -r 50 -t GET -u http://$HOST:$HTTP/ \
+    -l 30 -p 3 -w 1 -y 1 -n 1 -z 1 2>&1 | tail -5
+sleep 5
+
+# ── TEST 6: h2load - HTTP/2 stream flood ──────────
+echo ""
+echo "[6/9] H2LOAD - HTTP/2 stream flood (20s)"
+echo "  10 connections x 100 concurrent streams = 1000 parallel"
+h2load -n 10000 -c 10 -m 100 -t 2 \
+    https://$HOST:$TLS/health 2>&1 | grep -E "finished|requests:|status codes:|traffic:"
+H2=$(metric 'rawrelay_http2_streams_total{worker="0"}')
+echo "  HTTP/2 streams total: ${H2:-0}"
+sleep 5
+
+# ── TEST 7: Fuzz - binary garbage ─────────────────
+echo ""
+echo "[7/9] FUZZ - Binary garbage, oversized headers, malformed HTTP"
+BEFORE_PE=$(metric 'rawrelay_errors_total{worker="0",type="parse_error"}')
+
+echo "  a) 20 connections of /dev/urandom (should not crash)"
+for i in $(seq 1 20); do
+    (head -c 4096 /dev/urandom | nc -w 3 $HOST $HTTP > /dev/null 2>&1) &
+done
+wait
+echo "     Server alive: $(curl -s -o /dev/null -w '%{http_code}' http://$HOST:$HTTP/health)"
+
+echo "  b) 10 oversized header attacks (100KB headers)"
+for i in $(seq 1 10); do
+    (
+        printf "GET / HTTP/1.1\r\nHost: localhost\r\n"
+        printf "X-Garbage: "
+        head -c 102400 /dev/urandom | base64 | tr -d '\n'
+        printf "\r\n\r\n"
+    ) | nc -w 3 $HOST $HTTP > /dev/null 2>&1 &
+done
+wait
+echo "     Server alive: $(curl -s -o /dev/null -w '%{http_code}' http://$HOST:$HTTP/health)"
+
+echo "  c) 10 malformed HTTP lines"
+for i in $(seq 1 10); do
+    (
+        printf "GARBAGEMETHOD /not/real HXXP/9.9\r\n\r\n"
+    ) | nc -w 3 $HOST $HTTP > /dev/null 2>&1 &
+done
+wait
+echo "     Server alive: $(curl -s -o /dev/null -w '%{http_code}' http://$HOST:$HTTP/health)"
+
+echo "  d) 10 incomplete requests (just newlines)"
+for i in $(seq 1 10); do
+    (printf "\r\n\r\n\r\n") | nc -w 3 $HOST $HTTP > /dev/null 2>&1 &
+done
+wait
+echo "     Server alive: $(curl -s -o /dev/null -w '%{http_code}' http://$HOST:$HTTP/health)"
+
+AFTER_PE=$(metric 'rawrelay_errors_total{worker="0",type="parse_error"}')
+echo "  Parse errors: $(( ${AFTER_PE:-0} - ${BEFORE_PE:-0} ))"
+sleep 5
+
+# ── TEST 8: Connection exhaustion ─────────────────
+echo ""
+echo "[8/9] CONNECTION EXHAUSTION - 500 raw TCP sockets held open"
+echo "  Open sockets, hold them, see if server still serves new ones"
+for i in $(seq 1 500); do
+    (sleep 20 | nc -w 21 $HOST $HTTP > /dev/null 2>&1) &
+done
+sleep 3
+ACTIVE=$(metric 'rawrelay_active_connections{worker="0"}')
+SLOTS=$(metric 'rawrelay_slots_used{worker="0",tier="normal"}')
+echo "  Active connections: ${ACTIVE:-0}"
+echo "  Slots used: ${SLOTS:-0}/15"
+
+echo "  Can we still get through?"
+RESP=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://$HOST:$HTTP/health)
+echo "  Health check response: $RESP"
+
+SLOT_REJ=$(metric 'rawrelay_connections_rejected_total{worker="0",reason="slot_limit"}')
+RATE_REJ=$(metric 'rawrelay_connections_rejected_total{worker="0",reason="rate_limit"}')
+echo "  Slot rejections total: ${SLOT_REJ:-0}"
+echo "  Rate rejections total: ${RATE_REJ:-0}"
+
+kill $(jobs -p) 2>/dev/null
+wait 2>/dev/null
+sleep 5
+
+# ── TEST 9: EVERYTHING AT ONCE (60s) ─────────────
+echo ""
+echo "[9/9] ARMAGEDDON - all tools simultaneously for 60 seconds"
+echo "  wrk + h2load + slowhttptest + fuzz + connection exhaustion"
+
+# wrk sustained flood
+wrk -t2 -c100 -d60s http://$HOST:$HTTP/health > /tmp/arma_wrk.txt 2>&1 &
+PID_WRK=$!
+
+# h2load stream flood
+h2load -n 50000 -c 5 -m 50 -t 2 https://$HOST:$TLS/health > /tmp/arma_h2.txt 2>&1 &
+PID_H2=$!
+
+# slowhttptest slowloris
+slowhttptest -c 100 -H -i 10 -r 25 -t GET \
+    -u http://$HOST:$HTTP/health -l 55 -p 3 > /tmp/arma_slow.txt 2>&1 &
+PID_SLOW=$!
+
+# Connection holders
+for i in $(seq 1 50); do
+    (printf "GET / HTTP/1.1\r\nHost: localhost\r\n"; sleep 55) | nc -w 56 $HOST $HTTP > /dev/null 2>&1 &
+done
+
+# Periodic fuzz bursts
+for round in $(seq 1 6); do
+    for i in $(seq 1 5); do
+        (head -c 2048 /dev/urandom | nc -w 2 $HOST $HTTP > /dev/null 2>&1) &
+    done
+    sleep 10
+done &
+PID_FUZZ=$!
+
+# TLS + 404 mix
+for round in $(seq 1 12); do
+    for i in $(seq 1 5); do
+        curl -sk -o /dev/null --max-time 2 https://$HOST:$TLS/health &
+        curl -s -o /dev/null --max-time 2 http://$HOST:$HTTP/nope_$round &
+    done
+    sleep 5
+done &
+PID_MIX=$!
+
+echo "  All weapons firing..."
+wait $PID_WRK
+echo ""
+echo "  -- wrk results --"
+cat /tmp/arma_wrk.txt | grep -E "Latency|Req/Sec|requests in|Transfer|Socket errors|Non-2xx"
+echo ""
+echo "  -- h2load results --"
+wait $PID_H2 2>/dev/null
+cat /tmp/arma_h2.txt 2>/dev/null | grep -E "finished|requests:|status codes:|traffic:"
+
+kill $(jobs -p) 2>/dev/null
+wait 2>/dev/null
+
+echo ""
+echo "============================================"
+echo "  HARDENING SUITE COMPLETE - FINAL REPORT"
+echo "============================================"
+echo ""
+
+# Check server survived
+ALIVE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://$HOST:$HTTP/health)
+echo "SERVER STATUS: $ALIVE"
+echo ""
+
+echo "--- Worker 0 ---"
+curl -s http://$HOST:$HTTP/metrics 2>/dev/null | grep -E '^rawrelay_(requests_total|connections_accepted|connections_rejected|keepalive|slowloris|tls_handshakes|http2_streams_total|http_requests_by_class|response_bytes|errors_total|slots_used|rate_limiter)\{worker="0"' | sort
+echo ""
+echo "--- Worker 1 ---"
+curl -s http://$HOST:$HTTP/metrics 2>/dev/null | grep -E '^rawrelay_(requests_total|connections_accepted|connections_rejected|keepalive|slowloris|tls_handshakes|http2_streams_total|http_requests_by_class|response_bytes|errors_total|slots_used|rate_limiter)\{worker="1"' | sort

--- a/tools/stress_real.sh
+++ b/tools/stress_real.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+# Real stress test for rawrelay-server
+# Tests each feature independently by restarting the server between tests
+# Usage: Run from sendrawtx/ directory
+
+SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
+HTTP_PORT=8080
+TLS_PORT=8443
+HOST=localhost
+METRICS="http://$HOST:$HTTP_PORT/metrics"
+CONFIG=/tmp/rawrelay-test-active.ini
+LOGFILE=/tmp/rawrelay-test.log
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASSES=$((PASSES+1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAILS=$((FAILS+1)); }
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+header() { echo -e "\n${CYAN}=== $1 ===${NC}"; }
+
+PASSES=0
+FAILS=0
+
+get_metric() {
+    local val
+    val=$(curl -s $METRICS 2>/dev/null | grep "^$1" | head -1 | awk '{print $2}' | cut -d. -f1)
+    echo "${val:-0}"
+}
+
+start_server() {
+    # $1 = rps, $2 = burst, $3 = normal_max, $4 = read_timeout
+    local RPS=${1:-1000}
+    local BURST=${2:-2000}
+    local NORMAL=${3:-15}
+    local TIMEOUT=${4:-10}
+
+    killall -9 rawrelay-server 2>/dev/null || true
+    sleep 1
+
+    cat > $CONFIG << EOF
+[network]
+chain = regtest
+[server]
+port = $HTTP_PORT
+max_connections = 1000
+read_timeout = $TIMEOUT
+[buffer]
+initial_size = 4096
+max_size = 16777216
+[tiers]
+large_threshold = 65536
+huge_threshold = 1048576
+[static]
+dir = $SRCDIR/static
+cache_max_age = 0
+[slots]
+normal_max = $NORMAL
+large_max = 3
+huge_max = 1
+[ratelimit]
+rps = $RPS
+burst = $BURST
+[tls]
+enabled = 1
+port = $TLS_PORT
+cert_file = /tmp/rr.crt
+key_file = /tmp/rr.key
+http2_enabled = 1
+[logging]
+verbose = 1
+EOF
+
+    cd "$SRCDIR"
+    nohup ./rawrelay-server -w 1 $CONFIG > $LOGFILE 2>&1 &
+    sleep 2
+
+    if ! curl -s -o /dev/null http://$HOST:$HTTP_PORT/health 2>/dev/null; then
+        fail "Server failed to start"
+        return 1
+    fi
+}
+
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║          RAWRELAY STRESS TEST SUITE v2              ║"
+echo "╚══════════════════════════════════════════════════════╝"
+
+# Generate TLS cert if needed
+if [ ! -f /tmp/rr.crt ]; then
+    openssl req -x509 -newkey rsa:2048 -keyout /tmp/rr.key -out /tmp/rr.crt \
+        -days 1 -nodes -subj '/CN=localhost' 2>/dev/null
+fi
+
+# ============================================================
+header "TEST 1: Slot Saturation"
+info "Config: normal_max=10, rps=1000 (no rate limit interference)"
+start_server 1000 2000 10
+
+# Hold connections open with incomplete HTTP requests (no final \r\n)
+# This keeps the slot occupied waiting for more data
+for i in $(seq 1 15); do
+    (echo -ne "GET /health HTTP/1.1\r\nHost: localhost\r\n"; sleep 15) | nc -w 16 $HOST $HTTP_PORT > /dev/null 2>&1 &
+done
+
+sleep 2
+ACTIVE=$(get_metric 'rawrelay_active_connections{worker="0"}')
+info "Active connections holding slots: $ACTIVE"
+
+# Try more requests while slots are full
+for i in $(seq 1 10); do
+    curl -s -o /dev/null --max-time 2 http://$HOST:$HTTP_PORT/health 2>/dev/null &
+done
+sleep 1
+
+REJECTS=$(get_metric 'rawrelay_connections_rejected_total{worker="0",reason="slot_limit"}')
+info "Slot rejections: $REJECTS"
+
+# Kill held connections
+kill $(jobs -p) 2>/dev/null || true
+wait 2>/dev/null || true
+
+if [ "${ACTIVE:-0}" -ge 8 ]; then
+    pass "Slots filled to $ACTIVE/10"
+else
+    fail "Only $ACTIVE active connections (expected ~10+)"
+fi
+if [ "${REJECTS:-0}" -gt 0 ]; then
+    pass "Slot rejection: $REJECTS connections turned away"
+else
+    # Might pass if connections were fast enough to fit
+    info "No slot rejections (connections completed too quickly or nc piped too fast)"
+fi
+
+# ============================================================
+header "TEST 2: Slowloris Detection"
+info "Config: normal_max=15, rps=1000"
+start_server 1000 2000 15
+
+BEFORE=$(get_metric 'rawrelay_slowloris_kills_total{worker="0"}')
+
+# Drip-feed bytes extremely slowly
+for i in $(seq 1 3); do
+    (
+        echo -ne "G"; sleep 2
+        echo -ne "E"; sleep 2
+        echo -ne "T"; sleep 2
+        echo -ne " "; sleep 2
+        echo -ne "/"; sleep 2
+        echo -ne " "; sleep 2
+        echo -ne "H"; sleep 2
+        echo -ne "T"; sleep 20
+    ) | nc -w 30 $HOST $HTTP_PORT > /dev/null 2>&1 &
+done
+
+info "Waiting for slowloris kill (~15-20s)..."
+sleep 22
+
+AFTER=$(get_metric 'rawrelay_slowloris_kills_total{worker="0"}')
+KILLS=$((${AFTER:-0} - ${BEFORE:-0}))
+
+kill $(jobs -p) 2>/dev/null || true
+wait 2>/dev/null || true
+
+if [ "$KILLS" -gt 0 ]; then
+    pass "Slowloris: $KILLS slow connections killed"
+else
+    fail "Slowloris: no kills (check slowloris config thresholds)"
+fi
+
+# ============================================================
+header "TEST 3: Rate Limiting"
+info "Config: rps=5, burst=10"
+start_server 5 10 100
+
+# Exhaust the burst bucket
+for i in $(seq 1 30); do
+    curl -s -o /dev/null --max-time 1 http://$HOST:$HTTP_PORT/health &
+done
+wait
+
+RATE_REJECTS=$(get_metric 'rawrelay_connections_rejected_total{worker="0",reason="rate_limit"}')
+
+if [ "${RATE_REJECTS:-0}" -gt 0 ]; then
+    pass "Rate limiting: $RATE_REJECTS requests rejected (burst exhausted)"
+else
+    fail "Rate limiting: 0 rejections"
+fi
+
+# ============================================================
+header "TEST 4: Read Timeout"
+info "Config: read_timeout=5 (short for testing)"
+start_server 1000 2000 100 5
+
+# Send incomplete request, wait for timeout
+(echo -ne "GET /health HTTP/1.1\r\nHost: localhost\r\n"; sleep 10) | nc -w 11 $HOST $HTTP_PORT > /dev/null 2>&1 &
+NCPID=$!
+
+info "Waiting for read timeout (5s + buffer)..."
+sleep 8
+
+TIMEOUTS=$(get_metric 'rawrelay_errors_total{worker="0",type="timeout"}')
+kill $NCPID 2>/dev/null
+wait $NCPID 2>/dev/null
+
+if [ "${TIMEOUTS:-0}" -gt 0 ]; then
+    pass "Timeout: $TIMEOUTS connections timed out"
+else
+    fail "Timeout: no timeouts (check read_timeout)"
+fi
+
+# ============================================================
+header "TEST 5: TLS + HTTP/2"
+info "Config: standard TLS"
+start_server 1000 2000 100
+
+for i in $(seq 1 10); do
+    curl -sk -o /dev/null https://$HOST:$TLS_PORT/health
+done
+
+TLS13=$(get_metric 'rawrelay_tls_handshakes_total{worker="0",protocol="TLSv1.3"}')
+H2=$(get_metric 'rawrelay_http2_streams_total{worker="0"}')
+
+if [ "${TLS13:-0}" -gt 0 ]; then
+    pass "TLS 1.3: $TLS13 handshakes"
+else
+    fail "TLS: no TLSv1.3 handshakes"
+fi
+if [ "${H2:-0}" -gt 0 ]; then
+    pass "HTTP/2: $H2 streams via ALPN"
+else
+    info "HTTP/2: 0 streams (curl might not support h2 over TLS here)"
+fi
+
+# ============================================================
+header "TEST 6: Keepalive Reuse"
+info "Config: standard (high limits)"
+# Server still running from TEST 5
+
+for i in $(seq 1 10); do
+    curl -s -o /dev/null \
+        http://$HOST:$HTTP_PORT/health \
+        http://$HOST:$HTTP_PORT/health \
+        http://$HOST:$HTTP_PORT/health \
+        http://$HOST:$HTTP_PORT/health \
+        http://$HOST:$HTTP_PORT/health
+done
+
+KA=$(get_metric 'rawrelay_keepalive_reuses_total{worker="0"}')
+
+if [ "${KA:-0}" -gt 0 ]; then
+    pass "Keepalive: $KA requests on reused connections"
+else
+    fail "Keepalive: no reuses"
+fi
+
+# ============================================================
+header "TEST 7: Bandwidth + Error Tracking"
+info "Config: standard"
+# Server still running
+
+BEFORE_BYTES=$(get_metric 'rawrelay_response_bytes_total{worker="0"}')
+BEFORE_404=$(get_metric 'rawrelay_http_requests_total{worker="0",status="404"}')
+
+# Fetch big pages
+for i in $(seq 1 5); do curl -s -o /dev/null http://$HOST:$HTTP_PORT/; done
+# Hit 404s
+for i in $(seq 1 5); do curl -s -o /dev/null http://$HOST:$HTTP_PORT/nope$i; done
+
+AFTER_BYTES=$(get_metric 'rawrelay_response_bytes_total{worker="0"}')
+AFTER_404=$(get_metric 'rawrelay_http_requests_total{worker="0",status="404"}')
+
+NEW_BYTES=$((${AFTER_BYTES:-0} - ${BEFORE_BYTES:-0}))
+NEW_404=$((${AFTER_404:-0} - ${BEFORE_404:-0}))
+
+if [ "$NEW_BYTES" -gt 100000 ]; then
+    pass "Bandwidth: ${NEW_BYTES} bytes tracked"
+else
+    fail "Bandwidth: only $NEW_BYTES bytes"
+fi
+if [ "$NEW_404" -ge 3 ]; then
+    pass "404 tracking: $NEW_404 counted"
+else
+    fail "404 tracking: only $NEW_404"
+fi
+
+# ============================================================
+header "TEST 8: Metrics Endpoint Completeness"
+info "Checking all expected metric families exist"
+
+EXPECTED_METRICS=(
+    "rawrelay_requests_total"
+    "rawrelay_connections_accepted_total"
+    "rawrelay_connections_rejected_total"
+    "rawrelay_active_connections"
+    "rawrelay_request_duration_seconds_bucket"
+    "rawrelay_http_requests_total"
+    "rawrelay_http_requests_by_class_total"
+    "rawrelay_requests_by_method_total"
+    "rawrelay_process_uptime_seconds"
+    "rawrelay_open_fds"
+    "rawrelay_max_fds"
+    "rawrelay_tls_handshakes_total"
+    "rawrelay_tls_cert_expiry_timestamp_seconds"
+    "rawrelay_http2_streams_total"
+    "rawrelay_errors_total"
+    "rawrelay_slots_used"
+    "rawrelay_slots_max"
+    "rawrelay_rate_limiter_entries"
+    "rawrelay_response_bytes_total"
+    "rawrelay_slowloris_kills_total"
+    "rawrelay_slot_promotion_failures_total"
+    "rawrelay_keepalive_reuses_total"
+    "rawrelay_rpc_broadcasts_total"
+    "rawrelay_rpc_broadcasts_success_total"
+    "rawrelay_rpc_broadcasts_failed_total"
+    "rawrelay_endpoint_requests_total"
+)
+
+METRICS_BODY=$(curl -s $METRICS)
+MISSING=0
+for m in "${EXPECTED_METRICS[@]}"; do
+    if ! echo "$METRICS_BODY" | grep -q "^$m"; then
+        fail "Missing metric: $m"
+        MISSING=$((MISSING+1))
+    fi
+done
+if [ $MISSING -eq 0 ]; then
+    pass "All ${#EXPECTED_METRICS[@]} metric families present"
+fi
+
+# ============================================================
+# CLEANUP
+killall rawrelay-server 2>/dev/null || true
+
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║               RESULTS                              ║"
+echo "╠══════════════════════════════════════════════════════╣"
+echo -e "║  ${GREEN}PASSED: $PASSES${NC}                                      ║"
+echo -e "║  ${RED}FAILED: $FAILS${NC}                                      ║"
+echo "╚══════════════════════════════════════════════════════╝"


### PR DESCRIPTION
## Summary
- **Grafana dashboard** (`contrib/grafana/rawrelay-dashboard.json`) — 20 panels across 4 rows covering every metric the server exposes. Import via Dashboards > Import > Upload JSON. Template variables for multi-instance/multi-worker filtering
- **Prometheus alerting rules** (`contrib/prometheus/alerts.yml`) — 10 alerts covering TLS cert expiry, slot/FD pressure, error rate spikes, rate limit storms, latency, and target availability
- Updated DEPLOY.md monitoring section to reference both files
- Added both to README documentation table

## Test plan
- [ ] Import dashboard JSON into Grafana — verify all panels load without query errors
- [ ] Load alert rules into Prometheus — verify `promtool check rules contrib/prometheus/alerts.yml` passes
- [ ] Run traffic against server, confirm dashboard panels update in real time