### PR TITLE
Fix 6 audit bugs: H2 routing, error metrics, keepalive state

### DIFF
--- a/contrib/prometheus/alerts.yml
+++ b/contrib/prometheus/alerts.yml
@@ -29,7 +29,7 @@ groups:
 
       # Slot usage above 90% on any tier
       - alert: RawRelaySlotPressure
-        expr: (rawrelay_slots_used / rawrelay_slots_max) > 0.9
+        expr: (rawrelay_slots_used / rawrelay_slots_max) > 0.9 and rawrelay_slots_max > 0
         for: 2m
         labels:
           severity: warning
@@ -72,7 +72,7 @@ groups:
 
       # File descriptor usage above 80%
       - alert: RawRelayFDPressure
-        expr: (rawrelay_open_fds / rawrelay_max_fds) > 0.8
+        expr: (rawrelay_open_fds / rawrelay_max_fds) > 0.8 and rawrelay_max_fds > 0
         for: 5m
         labels:
           severity: warning


### PR DESCRIPTION
## Summary

Fixes 6 bugs found during post-merge code audit:

- **HIGH**: `ROUTE_VERSION` missing from HTTP/2 switch — `/version` served 404 over H2
- **HIGH**: `connection_send_response()` never set `response_status`/`response_bytes` — all error responses (400, 413, 503) were invisible to Prometheus metrics
- **MEDIUM**: `connection_reset_for_keepalive()` didn't reset `response_status`, `response_bytes`, or regenerate `request_id` — stale metrics on keep-alive connections
- **MEDIUM**: `connection_send_error()` honored `keep_alive` flag — broken connections stayed open instead of closing
- **MEDIUM**: H2 request ID format `%xs` produced confusing IDs — changed to `%x-s` for clarity
- **MEDIUM**: `RawRelaySlotPressure` and `RawRelayFDPressure` alerts missing divide-by-zero guards

## Test plan

- [x] Clean build with `-Werror` (zero warnings)
- [x] `curl -sk https://localhost:8443/version --http2` returns `{"version":"0.1.0"}` (was 404)
- [x] Malformed request `printf 'GARBAGE\r\n\r\n' | nc localhost 8080` now tracked as `status="400"` in `/metrics`
- [x] Error responses include `X-Request-ID` header and `Connection: close`
- [ ] CI: all 10 matrix jobs pass