### PR TITLE
Fix 11 bugs from audit round 3

### DIFF
--- a/contrib/prometheus/alerts.yml
+++ b/contrib/prometheus/alerts.yml
@@ -41,8 +41,8 @@ groups:
       - alert: RawRelayHighErrorRate
         expr: >
           rate(rawrelay_http_requests_by_class_total{class="5xx"}[5m])
-          / rate(rawrelay_requests_total[5m]) > 0.05
-          and rate(rawrelay_requests_total[5m]) > 0
+          / ignoring(class) rate(rawrelay_requests_total[5m]) > 0.05
+          and ignoring(class) rate(rawrelay_requests_total[5m]) > 0
         for: 5m
         labels:
           severity: warning

--- a/include/master.h
+++ b/include/master.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include <stdbool.h>
+#include <signal.h>
 #include <sys/types.h>
 
 /*
@@ -28,9 +29,9 @@ typedef struct MasterProcess {
     pid_t *draining_pids;
     int num_draining;
 
-    /* Signal flags (set by signal handlers) */
-    volatile bool shutdown_requested;
-    volatile bool reload_requested;
+    /* Signal flags (set by signal handlers, must be sig_atomic_t for async-signal safety) */
+    volatile sig_atomic_t shutdown_requested;
+    volatile sig_atomic_t reload_requested;
 } MasterProcess;
 
 /*

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -532,6 +532,12 @@ int serve_acme_challenge_h2(Connection *conn, int32_t stream_id,
     WorkerProcess *worker = conn->worker;
     const char *acme_dir = worker->config->acme_challenge_dir;
 
+    /* Security: Reject if ACME challenge directory is not configured */
+    if (!acme_dir || acme_dir[0] == '\0') {
+        log_warn("ACME H2: Challenge directory not configured");
+        goto not_found;
+    }
+
     /* Extract token from path: /.well-known/acme-challenge/{token} */
     const size_t prefix_len = 27;  /* ".well-known/acme-challenge/" */
 

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,11 @@ int main(int argc, char **argv)
             benchmark_mode = 1;
             continue;
         }
-        if ((strcmp(argv[i], "-w") == 0 || strcmp(argv[i], "--workers") == 0) && i + 1 < argc) {
+        if (strcmp(argv[i], "-w") == 0 || strcmp(argv[i], "--workers") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "Error: %s requires a number argument\n", argv[i]);
+                return 1;
+            }
             /* Security: use strtol with proper error checking instead of atoi */
             char *endptr = NULL;
             const char *arg = argv[++i];

--- a/src/rate_limiter.c
+++ b/src/rate_limiter.c
@@ -148,7 +148,7 @@ static RateLimitEntry *get_entry(RateLimiter *rl, const RateLimitKey *key, doubl
     memcpy(&entry->key, key, sizeof(*key));
     entry->tokens = rl->burst;  /* Start with full bucket */
     entry->last_update = now;
-    entry->last_request = (time_t)now;  /* Integer seconds for TTL */
+    entry->last_request = time(NULL);  /* Wall clock for TTL comparison */
     entry->next = rl->buckets[bucket];
     rl->buckets[bucket] = entry;
     rl->num_entries++;
@@ -199,8 +199,8 @@ int rate_limiter_allow(RateLimiter *rl, const char *ip_str)
         return 0;
     }
 
-    /* Update last request time for TTL (integer seconds) */
-    entry->last_request = (time_t)now;
+    /* Update last request time for TTL (wall clock for cleanup comparison) */
+    entry->last_request = time(NULL);
 
     /* Replenish tokens */
     replenish_tokens(rl, entry, now);

--- a/src/worker.c
+++ b/src/worker.c
@@ -28,7 +28,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-/* Global worker pointer for signal handler */
+/* Global worker pointer (reserved for future signal handler use) */
 static WorkerProcess *g_worker = NULL;
 
 /* Forward declarations */
@@ -727,6 +727,6 @@ void worker_main(int worker_id, Config *config)
     /* Cleanup and exit */
     worker_cleanup(&worker);
 
-    log_info("Exiting with %lu connections processed", worker.requests_processed);
+    log_info("Exiting with %lu connections processed", (unsigned long)worker.requests_processed);
     exit(0);
 }


### PR DESCRIPTION
## Summary
- **5 HIGH**: Rate limiter clock domain mismatch (entries instantly expired), H2 strndup() NULL crash, dead PromQL alert, ACME path traversal to root, num_workers defaulting to 100
- **6 MEDIUM**: H2 slowloris false kills, signal handler type safety, reload skipping dead workers, uint64_t format UB, requests_processed counting connections not requests, -w flag missing arg handling

## Files changed (9)
`rate_limiter.c` `http2.c` `alerts.yml` `endpoints.c` `connection.c` `master.c` `master.h` `main.c` `worker.c`

## Test plan
- [x] Clean build with -Werror, zero warnings
- [x] All H1 endpoints return 200
- [x] ACME returns 404 when dir unconfigured (not serving from root)
- [x] `-w` without argument prints error and exits with code 1
- [x] Workers default to CPU count (24), not max_connections (100)
- [x] requests_processed counts per-request: 5 keepalive + 2 = 7 (was 3 per-connection)
- [ ] CI passes